### PR TITLE
fix(customwebwalker): implement runnable CustomWebWalkerScript and bump plugin version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
@@ -21,7 +21,7 @@ import net.runelite.client.plugins.microbot.PluginConstants;
 @Slf4j
 public class CustomWebWalkerPlugin extends Plugin {
 
-    static final String version = "1.0.0";
+    static final String version = "1.0.1";
 
     @Inject
     private CustomWebWalkerScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
@@ -1,26 +1,60 @@
 package net.runelite.client.plugins.microbot.customwebwalker;
 
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.CustomWebWalker;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
-public final class CustomWebWalker {
+@Slf4j
+public class CustomWebWalkerScript extends Script {
 
-    private CustomWebWalker() {
+    private final CustomWebWalkerConfig config;
+
+    @Inject
+    public CustomWebWalkerScript(CustomWebWalkerConfig config) {
+        this.config = config;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(
-                destination,
-                reachedDistance,
-                timeoutMs
-        );
+    public boolean run() {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (!super.run()) {
+                    return;
+                }
+
+                WorldPoint destination = new WorldPoint(
+                        config.targetX(),
+                        config.targetY(),
+                        config.targetPlane()
+                );
+
+                if (destination.distanceTo(Rs2Player.getWorldLocation()) <= config.reachedDistance()) {
+                    return;
+                }
+
+                WalkerState result = CustomWebWalker.walkTo(
+                        destination,
+                        config.reachedDistance(),
+                        config.timeoutMs()
+                );
+                log.info("Custom web walker finished with state {}", result);
+            } catch (Exception ex) {
+                log.trace("Exception in CustomWebWalkerScript loop: ", ex);
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+        return true;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination, reachedDistance);
-    }
-
-    public static WalkerState walkTo(WorldPoint destination) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination);
+    @Override
+    public void shutdown() {
+        super.shutdown();
     }
 }


### PR DESCRIPTION
### Motivation
- The repository contained a placeholder class conflicting with the util `CustomWebWalker` and caused compilation errors like `class CustomWebWalker is public, should be declared in a file named CustomWebWalker.java`.
- The plugin should provide a runnable script that uses the existing `net.runelite.client.plugins.microbot.util.walker.CustomWebWalker` to navigate to a configured destination.
- The plugin version must be incremented when the implementation changes to follow the repo versioning guidelines.

### Description
- Replace the static wrapper with a new `CustomWebWalkerScript` class that extends `Script`, is `@Inject`ed with `CustomWebWalkerConfig`, and schedules a periodic walk loop.  
- The script builds a destination `WorldPoint` from `config` and calls `CustomWebWalker.walkTo(destination, config.reachedDistance(), config.timeoutMs())`, and logs the resulting `WalkerState`.  
- Bumped `CustomWebWalkerPlugin` `version` from `1.0.0` to `1.0.1`.  
- Kept lifecycle wiring in `CustomWebWalkerPlugin` to call `script.run()` on startup and `script.shutdown()` on shutdown.

### Testing
- No automated tests or `./gradlew` build were executed against the modified code after the change.  
- No CI runs were triggered as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647584efb8833085e1be34e8d3f806)