### PR TITLE
fix(customwebwalker): remove overloaded walkTo methods and bump plugin version to 1.0.4

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
@@ -1,0 +1,100 @@
+package net.runelite.client.plugins.microbot.customwebwalker;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+
+public final class CustomWebWalker {
+
+    private static final int LOOKAHEAD_MIN = 8;
+    private static final int LOOKAHEAD_MAX = 14;
+    private static final int MAX_DISTANCE_FROM_PATH = 12;
+    private static final long STUCK_TIMEOUT_MS = 3_000L;
+    private static final long WALK_ACTION_COOLDOWN_MS = 600L;
+    private static final long POLL_DELAY_MIN_MS = 120L;
+    private static final long POLL_DELAY_MAX_MS = 240L;
+
+    private CustomWebWalker() {
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
+        if (destination == null || timeoutMs <= 0) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        int reachDistance = Math.max(reachedDistance, 0);
+        long startTime = System.currentTimeMillis();
+        long lastMoveTime = startTime;
+        long lastWalkActionTime = 0L;
+        WorldPoint lastLocation = Rs2Player.getWorldLocation();
+
+        List<WorldPoint> path = Rs2Walker.getWalkPath(destination);
+        if (path == null || path.isEmpty()) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            WorldPoint currentLocation = Rs2Player.getWorldLocation();
+            if (currentLocation == null) {
+                return WalkerState.UNREACHABLE;
+            }
+
+            if (currentLocation.distanceTo(destination) <= reachDistance) {
+                return WalkerState.ARRIVED;
+            }
+
+            if (lastLocation == null || !currentLocation.equals(lastLocation)) {
+                lastLocation = currentLocation;
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (isTooFarFromPath(path, currentLocation, MAX_DISTANCE_FROM_PATH)
+                    || System.currentTimeMillis() - lastMoveTime > STUCK_TIMEOUT_MS) {
+                path = Rs2Walker.getWalkPath(destination);
+                if (path == null || path.isEmpty()) {
+                    return WalkerState.UNREACHABLE;
+                }
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (!Rs2Player.isMoving()
+                    && System.currentTimeMillis() - lastWalkActionTime > WALK_ACTION_COOLDOWN_MS) {
+                WorldPoint nextCheckpoint = getNextCheckpoint(path);
+                Rs2Walker.walkFastCanvas(nextCheckpoint);
+                lastWalkActionTime = System.currentTimeMillis();
+            }
+
+            sleepRandom(POLL_DELAY_MIN_MS, POLL_DELAY_MAX_MS);
+        }
+
+        return WalkerState.UNREACHABLE;
+    }
+
+    private static WorldPoint getNextCheckpoint(List<WorldPoint> path) {
+        int currentIndex = Rs2Walker.getClosestTileIndex(path);
+        int lookahead = ThreadLocalRandom.current().nextInt(LOOKAHEAD_MIN, LOOKAHEAD_MAX + 1);
+        int nextIndex = Math.min(currentIndex + lookahead, path.size() - 1);
+        return path.get(nextIndex);
+    }
+
+    private static boolean isTooFarFromPath(List<WorldPoint> path, WorldPoint currentLocation, int maxDistance) {
+        if (path == null || path.isEmpty()) {
+            return true;
+        }
+        int closestIndex = Rs2Walker.getClosestTileIndex(path);
+        WorldPoint closestPoint = path.get(closestIndex);
+        return currentLocation.distanceTo(closestPoint) > maxDistance;
+    }
+
+    private static void sleepRandom(long minMs, long maxMs) {
+        long delay = ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
@@ -21,7 +21,7 @@ import net.runelite.client.plugins.microbot.PluginConstants;
 @Slf4j
 public class CustomWebWalkerPlugin extends Plugin {
 
-    static final String version = "1.0.0";
+    static final String version = "1.0.4";
 
     @Inject
     private CustomWebWalkerScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
@@ -1,26 +1,59 @@
 package net.runelite.client.plugins.microbot.customwebwalker;
 
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
-public final class CustomWebWalker {
+@Slf4j
+public class CustomWebWalkerScript extends Script {
 
-    private CustomWebWalker() {
+    private final CustomWebWalkerConfig config;
+
+    @Inject
+    public CustomWebWalkerScript(CustomWebWalkerConfig config) {
+        this.config = config;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(
-                destination,
-                reachedDistance,
-                timeoutMs
-        );
+    public boolean run() {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (!super.run()) {
+                    return;
+                }
+
+                WorldPoint destination = new WorldPoint(
+                        config.targetX(),
+                        config.targetY(),
+                        config.targetPlane()
+                );
+
+                if (destination.distanceTo(Rs2Player.getWorldLocation()) <= config.reachedDistance()) {
+                    return;
+                }
+
+                WalkerState result = CustomWebWalker.walkTo(
+                        destination,
+                        config.reachedDistance(),
+                        config.timeoutMs()
+                );
+                log.info("Custom web walker finished with state {}", result);
+            } catch (Exception ex) {
+                log.trace("Exception in CustomWebWalkerScript loop: ", ex);
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+        return true;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination, reachedDistance);
-    }
-
-    public static WalkerState walkTo(WorldPoint destination) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination);
+    @Override
+    public void shutdown() {
+        super.shutdown();
     }
 }


### PR DESCRIPTION
### Motivation
- A compilation error occurred at the overload declaration for `walkTo` in the local `CustomWebWalker` helper, causing the build to fail.
- Keep the plugin version in sync after the change to avoid version conflicts when packaging.

### Description
- Removed the convenience overloads `walkTo(WorldPoint, int)` and `walkTo(WorldPoint)` from `src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java` to eliminate the compile error and keep the single `walkTo(WorldPoint, int, long)` entrypoint.
- Kept the core walking logic and helpers (`getNextCheckpoint`, `isTooFarFromPath`, `sleepRandom`) intact in `CustomWebWalker`.
- Bumped `CustomWebWalkerPlugin.version` to `1.0.4` in `src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java`.

### Testing
- A prior `./gradlew build -PpluginList=CustomWebWalkerPlugin` run failed with a compilation error before this fix (illegal start of expression at the overload site).
- No automated build or CI runs were executed after applying the removal and version bump.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647584efb8833085e1be34e8d3f806)