### PR TITLE
Accept comma-formatted coordinates for CustomWebWalker and bump version to 1.0.6

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
@@ -1,0 +1,108 @@
+package net.runelite.client.plugins.microbot.customwebwalker;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+
+public final class CustomWebWalker {
+
+    private static final int LOOKAHEAD_MIN = 8;
+    private static final int LOOKAHEAD_MAX = 14;
+    private static final int MAX_DISTANCE_FROM_PATH = 12;
+    private static final long STUCK_TIMEOUT_MS = 3_000L;
+    private static final long WALK_ACTION_COOLDOWN_MS = 600L;
+    private static final long POLL_DELAY_MIN_MS = 120L;
+    private static final long POLL_DELAY_MAX_MS = 240L;
+
+    private CustomWebWalker() {
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
+        if (destination == null || timeoutMs <= 0) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        int reachDistance = Math.max(reachedDistance, 0);
+        long startTime = System.currentTimeMillis();
+        long lastMoveTime = startTime;
+        long lastWalkActionTime = 0L;
+        WorldPoint lastLocation = Rs2Player.getWorldLocation();
+
+        List<WorldPoint> path = Rs2Walker.getWalkPath(destination);
+        if (path == null || path.isEmpty()) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            WorldPoint currentLocation = Rs2Player.getWorldLocation();
+            if (currentLocation == null) {
+                return WalkerState.UNREACHABLE;
+            }
+
+            if (currentLocation.distanceTo(destination) <= reachDistance) {
+                return WalkerState.ARRIVED;
+            }
+
+            if (lastLocation == null || !currentLocation.equals(lastLocation)) {
+                lastLocation = currentLocation;
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (isTooFarFromPath(path, currentLocation, MAX_DISTANCE_FROM_PATH)
+                    || System.currentTimeMillis() - lastMoveTime > STUCK_TIMEOUT_MS) {
+                path = Rs2Walker.getWalkPath(destination);
+                if (path == null || path.isEmpty()) {
+                    return WalkerState.UNREACHABLE;
+                }
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (!Rs2Player.isMoving()
+                    && System.currentTimeMillis() - lastWalkActionTime > WALK_ACTION_COOLDOWN_MS) {
+                WorldPoint nextCheckpoint = getNextCheckpoint(path);
+                Rs2Walker.walkFastCanvas(nextCheckpoint);
+                lastWalkActionTime = System.currentTimeMillis();
+            }
+
+            sleepRandom(POLL_DELAY_MIN_MS, POLL_DELAY_MAX_MS);
+        }
+
+        return WalkerState.UNREACHABLE;
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
+        return walkTo(destination, reachedDistance, 90_000L);
+    }
+
+    public static WalkerState walkTo(WorldPoint destination) {
+        return walkTo(destination, 3, 90_000L);
+    }
+
+    private static WorldPoint getNextCheckpoint(List<WorldPoint> path) {
+        int currentIndex = Rs2Walker.getClosestTileIndex(path);
+        int lookahead = ThreadLocalRandom.current().nextInt(LOOKAHEAD_MIN, LOOKAHEAD_MAX + 1);
+        int nextIndex = Math.min(currentIndex + lookahead, path.size() - 1);
+        return path.get(nextIndex);
+    }
+
+    private static boolean isTooFarFromPath(List<WorldPoint> path, WorldPoint currentLocation, int maxDistance) {
+        if (path == null || path.isEmpty()) {
+            return true;
+        }
+        int closestIndex = Rs2Walker.getClosestTileIndex(path);
+        WorldPoint closestPoint = path.get(closestIndex);
+        return currentLocation.distanceTo(closestPoint) > maxDistance;
+    }
+
+    private static void sleepRandom(long minMs, long maxMs) {
+        long delay = ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerConfig.java
@@ -23,8 +23,8 @@ public interface CustomWebWalkerConfig extends Config {
             position = 0,
             section = destinationSection
     )
-    default int targetX() {
-        return 3208;
+    default String targetX() {
+        return "3208";
     }
 
     @ConfigItem(
@@ -34,8 +34,8 @@ public interface CustomWebWalkerConfig extends Config {
             position = 1,
             section = destinationSection
     )
-    default int targetY() {
-        return 3220;
+    default String targetY() {
+        return "3220";
     }
 
     @ConfigItem(

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
@@ -21,7 +21,7 @@ import net.runelite.client.plugins.microbot.PluginConstants;
 @Slf4j
 public class CustomWebWalkerPlugin extends Plugin {
 
-    static final String version = "1.0.0";
+    static final String version = "1.0.6";
 
     @Inject
     private CustomWebWalkerScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
@@ -1,26 +1,77 @@
 package net.runelite.client.plugins.microbot.customwebwalker;
 
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
-public final class CustomWebWalker {
+@Slf4j
+public class CustomWebWalkerScript extends Script {
 
-    private CustomWebWalker() {
+    private final CustomWebWalkerConfig config;
+
+    @Inject
+    public CustomWebWalkerScript(CustomWebWalkerConfig config) {
+        this.config = config;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(
-                destination,
-                reachedDistance,
-                timeoutMs
-        );
+    public boolean run() {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (!super.run()) {
+                    return;
+                }
+
+                int targetX = parseCoordinate(config.targetX(), 3208, "X");
+                int targetY = parseCoordinate(config.targetY(), 3220, "Y");
+                WorldPoint destination = new WorldPoint(
+                        targetX,
+                        targetY,
+                        config.targetPlane()
+                );
+
+                if (destination.distanceTo(Rs2Player.getWorldLocation()) <= config.reachedDistance()) {
+                    return;
+                }
+
+                WalkerState result = CustomWebWalker.walkTo(
+                        destination,
+                        config.reachedDistance(),
+                        config.timeoutMs()
+                );
+                log.info("Custom web walker finished with state {}", result);
+            } catch (Exception ex) {
+                log.trace("Exception in CustomWebWalkerScript loop: ", ex);
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+        return true;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination, reachedDistance);
+    @Override
+    public void shutdown() {
+        super.shutdown();
     }
 
-    public static WalkerState walkTo(WorldPoint destination) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination);
+    private int parseCoordinate(String value, int fallback, String label) {
+        if (value == null) {
+            return fallback;
+        }
+        String sanitized = value.replace(",", "").trim();
+        if (sanitized.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(sanitized);
+        } catch (NumberFormatException ex) {
+            log.warn("Invalid {} coordinate '{}', using default {}", label, value, fallback);
+            return fallback;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Allow coordinate inputs that include thousands separators (e.g., "3,164") because the config previously enforced numeric types and reformatted inputs. 
- Make the script robust to comma-formatted or otherwise malformed coordinate strings and provide safe fallbacks.
- Provide an in-repo `CustomWebWalker` implementation with convenient overloads for callers.
- Keep the plugin version in sync after the API/config change.

### Description
- Changed `targetX()` and `targetY()` in `CustomWebWalkerConfig` from `int` to `String` with defaults of `"3208"` and `"3220"` to preserve user-entered formatting.
- Added `parseCoordinate(String value, int fallback, String label)` to `CustomWebWalkerScript` which strips commas, trims, parses to `int`, and logs/wraps to a fallback on failure.
- Updated `CustomWebWalkerScript` to parse the string coordinates into integers and build the `WorldPoint`, and retained the scheduled run loop that calls `CustomWebWalker.walkTo`.
- Added a new `CustomWebWalker` class with `walkTo` overloads and walking logic, and bumped `CustomWebWalkerPlugin` version to `1.0.6`.

### Testing
- No automated tests or CI jobs were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647584efb8833085e1be34e8d3f806)