### PR TITLE
customwebwalker: add minimap "Set destination" menu entry; walker & config improvements (v1.0.8)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalker.java
@@ -1,0 +1,111 @@
+package net.runelite.client.plugins.microbot.customwebwalker;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.walker.WalkerState;
+
+public final class CustomWebWalker {
+
+    private static final int LOOKAHEAD_MIN = 8;
+    private static final int LOOKAHEAD_MAX = 14;
+    private static final int MAX_DISTANCE_FROM_PATH = 12;
+    private static final long STUCK_TIMEOUT_MS = 3_000L;
+    private static final long WALK_ACTION_COOLDOWN_MS = 600L;
+    private static final long POLL_DELAY_MIN_MS = 120L;
+    private static final long POLL_DELAY_MAX_MS = 240L;
+
+    private CustomWebWalker() {
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
+        if (destination == null || timeoutMs <= 0) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        int reachDistance = Math.max(reachedDistance, 0);
+        long startTime = System.currentTimeMillis();
+        long lastMoveTime = startTime;
+        long lastWalkActionTime = 0L;
+        WorldPoint lastLocation = Rs2Player.getWorldLocation();
+
+        List<WorldPoint> path = Rs2Walker.getWalkPath(destination);
+        if (path == null || path.isEmpty()) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            WorldPoint currentLocation = Rs2Player.getWorldLocation();
+            if (currentLocation == null) {
+                return WalkerState.UNREACHABLE;
+            }
+
+            if (currentLocation.distanceTo(destination) <= reachDistance) {
+                return WalkerState.ARRIVED;
+            }
+
+            if (lastLocation == null || !currentLocation.equals(lastLocation)) {
+                lastLocation = currentLocation;
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (isTooFarFromPath(path, currentLocation, MAX_DISTANCE_FROM_PATH)
+                    || System.currentTimeMillis() - lastMoveTime > STUCK_TIMEOUT_MS) {
+                path = Rs2Walker.getWalkPath(destination);
+                if (path == null || path.isEmpty()) {
+                    return WalkerState.UNREACHABLE;
+                }
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (System.currentTimeMillis() - lastWalkActionTime > WALK_ACTION_COOLDOWN_MS) {
+                WorldPoint nextCheckpoint = getNextCheckpoint(path);
+                boolean shouldClickWhileMoving = Rs2Player.isMoving()
+                        && currentLocation.distanceTo(nextCheckpoint) > reachDistance + 2;
+                if (!Rs2Player.isMoving() || shouldClickWhileMoving) {
+                    Rs2Walker.walkFastCanvas(nextCheckpoint);
+                    lastWalkActionTime = System.currentTimeMillis();
+                }
+            }
+
+            sleepRandom(POLL_DELAY_MIN_MS, POLL_DELAY_MAX_MS);
+        }
+
+        return WalkerState.UNREACHABLE;
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
+        return walkTo(destination, reachedDistance, 90_000L);
+    }
+
+    public static WalkerState walkTo(WorldPoint destination) {
+        return walkTo(destination, 3, 90_000L);
+    }
+
+    private static WorldPoint getNextCheckpoint(List<WorldPoint> path) {
+        int currentIndex = Rs2Walker.getClosestTileIndex(path);
+        int lookahead = ThreadLocalRandom.current().nextInt(LOOKAHEAD_MIN, LOOKAHEAD_MAX + 1);
+        int nextIndex = Math.min(currentIndex + lookahead, path.size() - 1);
+        return path.get(nextIndex);
+    }
+
+    private static boolean isTooFarFromPath(List<WorldPoint> path, WorldPoint currentLocation, int maxDistance) {
+        if (path == null || path.isEmpty()) {
+            return true;
+        }
+        int closestIndex = Rs2Walker.getClosestTileIndex(path);
+        WorldPoint closestPoint = path.get(closestIndex);
+        return currentLocation.distanceTo(closestPoint) > maxDistance;
+    }
+
+    private static void sleepRandom(long minMs, long maxMs) {
+        long delay = ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerConfig.java
@@ -23,8 +23,8 @@ public interface CustomWebWalkerConfig extends Config {
             position = 0,
             section = destinationSection
     )
-    default int targetX() {
-        return 3208;
+    default String targetX() {
+        return "3208";
     }
 
     @ConfigItem(
@@ -34,8 +34,8 @@ public interface CustomWebWalkerConfig extends Config {
             position = 1,
             section = destinationSection
     )
-    default int targetY() {
-        return 3220;
+    default String targetY() {
+        return "3220";
     }
 
     @ConfigItem(

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerPlugin.java
@@ -1,8 +1,17 @@
 package net.runelite.client.plugins.microbot.customwebwalker;
 
 import com.google.inject.Provides;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -21,14 +30,33 @@ import net.runelite.client.plugins.microbot.PluginConstants;
 @Slf4j
 public class CustomWebWalkerPlugin extends Plugin {
 
-    static final String version = "1.0.0";
+    private static final String WALK_HERE = "Walk here";
+    private static final String SET_DESTINATION = "Set destination";
+    private static final String DESTINATION_TARGET = "Custom WebWalker";
+
+    static final String version = "1.0.8";
 
     @Inject
     private CustomWebWalkerScript script;
 
+    @Inject
+    private Client client;
+
+    @Inject
+    private ConfigManager configManager;
+
     @Provides
     CustomWebWalkerConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(CustomWebWalkerConfig.class);
+    }
+
+    @Subscribe
+    public void onMenuEntryAdded(MenuEntryAdded event) {
+        if (!WALK_HERE.equals(event.getOption()) || !event.getTarget().isEmpty()) {
+            return;
+        }
+
+        addMenuEntry(event, SET_DESTINATION, DESTINATION_TARGET, 1);
     }
 
     @Override
@@ -39,5 +67,43 @@ public class CustomWebWalkerPlugin extends Plugin {
     @Override
     protected void shutDown() {
         script.shutdown();
+    }
+
+    private void onMenuOptionClicked(MenuEntry entry) {
+        if (!SET_DESTINATION.equals(entry.getOption()) || !DESTINATION_TARGET.equals(entry.getTarget())) {
+            return;
+        }
+
+        WorldPoint destination = WorldPoint.fromScene(
+                client.getTopLevelWorldView(),
+                entry.getParam0(),
+                entry.getParam1(),
+                client.getTopLevelWorldView().getPlane()
+        );
+
+        if (destination == null) {
+            return;
+        }
+
+        configManager.setConfiguration(CustomWebWalkerConfig.configGroup, "targetX", Integer.toString(destination.getX()));
+        configManager.setConfiguration(CustomWebWalkerConfig.configGroup, "targetY", Integer.toString(destination.getY()));
+        configManager.setConfiguration(CustomWebWalkerConfig.configGroup, "targetPlane", destination.getPlane());
+    }
+
+    private void addMenuEntry(MenuEntryAdded event, String option, String target, int position) {
+        List<MenuEntry> entries = new LinkedList<>(Arrays.asList(client.getMenu().getMenuEntries()));
+
+        if (entries.stream().anyMatch(entry -> option.equals(entry.getOption()) && target.equals(entry.getTarget()))) {
+            return;
+        }
+
+        client.createMenuEntry(position)
+                .setOption(option)
+                .setTarget(target)
+                .setParam0(event.getActionParam0())
+                .setParam1(event.getActionParam1())
+                .setIdentifier(event.getIdentifier())
+                .setType(MenuAction.RUNELITE)
+                .onClick(this::onMenuOptionClicked);
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/customwebwalker/CustomWebWalkerScript.java
@@ -1,26 +1,77 @@
 package net.runelite.client.plugins.microbot.customwebwalker;
 
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.WalkerState;
 
-public final class CustomWebWalker {
+@Slf4j
+public class CustomWebWalkerScript extends Script {
 
-    private CustomWebWalker() {
+    private final CustomWebWalkerConfig config;
+
+    @Inject
+    public CustomWebWalkerScript(CustomWebWalkerConfig config) {
+        this.config = config;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(
-                destination,
-                reachedDistance,
-                timeoutMs
-        );
+    public boolean run() {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (!super.run()) {
+                    return;
+                }
+
+                int targetX = parseCoordinate(config.targetX(), 3208, "X");
+                int targetY = parseCoordinate(config.targetY(), 3220, "Y");
+                WorldPoint destination = new WorldPoint(
+                        targetX,
+                        targetY,
+                        config.targetPlane()
+                );
+
+                if (destination.distanceTo(Rs2Player.getWorldLocation()) <= config.reachedDistance()) {
+                    return;
+                }
+
+                WalkerState result = CustomWebWalker.walkTo(
+                        destination,
+                        config.reachedDistance(),
+                        config.timeoutMs()
+                );
+                log.info("Custom web walker finished with state {}", result);
+            } catch (Exception ex) {
+                log.trace("Exception in CustomWebWalkerScript loop: ", ex);
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+        return true;
     }
 
-    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination, reachedDistance);
+    @Override
+    public void shutdown() {
+        super.shutdown();
     }
 
-    public static WalkerState walkTo(WorldPoint destination) {
-        return net.runelite.client.plugins.microbot.util.walker.CustomWebWalker.walkTo(destination);
+    private int parseCoordinate(String value, int fallback, String label) {
+        if (value == null) {
+            return fallback;
+        }
+        String sanitized = value.replace(",", "").trim();
+        if (sanitized.isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(sanitized);
+        } catch (NumberFormatException ex) {
+            log.warn("Invalid {} coordinate '{}', using default {}", label, value, fallback);
+            return fallback;
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Provide a convenient way to set the CustomWebWalker destination by right-clicking the minimap and choosing a context menu entry. 
- Improve walking robustness by allowing additional clicks mid-move and adding randomized lookahead and conservative timeouts. 
- Preserve user-entered coordinate formatting and tolerate comma-separated or malformed coordinate strings. 
- Bump the plugin version to reflect behavior and API changes.

### Description

- Added a new `CustomWebWalker` utility implementing randomized lookahead, stuck/path recovery, and logic to call `Rs2Walker.walkFastCanvas` even while already moving when appropriate. 
- Changed `CustomWebWalkerConfig.targetX()` and `targetY()` from `int` to `String` and added `parseCoordinate(String, int, String)` in `CustomWebWalkerScript` to sanitize and parse coordinates with safe fallbacks. 
- Updated `CustomWebWalkerScript` to schedule a walking loop, build a `WorldPoint` from parsed config coordinates, invoke `CustomWebWalker.walkTo(...)`, and log the final `WalkerState`. 
- Added a minimap context menu entry by subscribing to `MenuEntryAdded`, creating a `Set destination` `RUNELITE` entry, handling the click to convert menu params to a `WorldPoint`, and saving `targetX`, `targetY`, and `targetPlane` via `ConfigManager`; also bumped plugin version to `1.0.8`.

### Testing

- No automated tests or CI jobs were executed for these changes. 
- No unit tests were added or run as part of this rollout. 
- Basic manual verification steps were prepared but not executed (not requested). 
- Compilation and runtime verification were not performed by automated tooling in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647584efb8833085e1be34e8d3f806)