### PR TITLE
fix(KSPAutoMiner): add CustomWebWalker, optional antiban toggle, bump version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/CustomWebWalker.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/CustomWebWalker.java
@@ -1,0 +1,112 @@
+package net.runelite.client.plugins.microbot.KSPAutoMiner;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+public final class CustomWebWalker {
+
+    private static final int LOOKAHEAD_MIN = 8;
+    private static final int LOOKAHEAD_MAX = 14;
+    private static final int MAX_DISTANCE_FROM_PATH = 12;
+    private static final long STUCK_TIMEOUT_MS = 3_000L;
+    private static final long WALK_ACTION_COOLDOWN_MS = 600L;
+    private static final long POLL_DELAY_MIN_MS = 120L;
+    private static final long POLL_DELAY_MAX_MS = 240L;
+
+    private CustomWebWalker() {
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance, long timeoutMs) {
+        if (destination == null || timeoutMs <= 0) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        int reachDistance = Math.max(reachedDistance, 0);
+        long startTime = System.currentTimeMillis();
+        long lastMoveTime = startTime;
+        long lastWalkActionTime = 0L;
+        WorldPoint lastLocation = Rs2Player.getWorldLocation();
+
+        List<WorldPoint> path = Rs2Walker.getWalkPath(destination);
+        if (path == null || path.isEmpty()) {
+            return WalkerState.UNREACHABLE;
+        }
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            WorldPoint currentLocation = Rs2Player.getWorldLocation();
+            if (currentLocation == null) {
+                return WalkerState.UNREACHABLE;
+            }
+
+            if (currentLocation.distanceTo(destination) <= reachDistance) {
+                return WalkerState.ARRIVED;
+            }
+
+            if (!currentLocation.equals(lastLocation)) {
+                lastLocation = currentLocation;
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (isTooFarFromPath(path, currentLocation, MAX_DISTANCE_FROM_PATH)
+                    || System.currentTimeMillis() - lastMoveTime > STUCK_TIMEOUT_MS) {
+                path = Rs2Walker.getWalkPath(destination);
+                if (path == null || path.isEmpty()) {
+                    return WalkerState.UNREACHABLE;
+                }
+                lastMoveTime = System.currentTimeMillis();
+            }
+
+            if (!Rs2Player.isMoving()
+                    && System.currentTimeMillis() - lastWalkActionTime > WALK_ACTION_COOLDOWN_MS) {
+                WorldPoint nextCheckpoint = getNextCheckpoint(path);
+                Rs2Walker.walkFastCanvas(nextCheckpoint);
+                lastWalkActionTime = System.currentTimeMillis();
+            }
+
+            sleepRandom(POLL_DELAY_MIN_MS, POLL_DELAY_MAX_MS);
+        }
+
+        return WalkerState.UNREACHABLE;
+    }
+
+    public static WalkerState walkTo(WorldPoint destination, int reachedDistance) {
+        return walkTo(destination, reachedDistance, 90_000L);
+    }
+
+    public static WalkerState walkTo(WorldPoint destination) {
+        return walkTo(destination, 3, 90_000L);
+    }
+
+    private static WorldPoint getNextCheckpoint(List<WorldPoint> path) {
+        int currentIndex = Rs2Walker.getClosestTileIndex(path);
+        int lookahead = ThreadLocalRandom.current().nextInt(LOOKAHEAD_MIN, LOOKAHEAD_MAX + 1);
+        int nextIndex = Math.min(currentIndex + lookahead, path.size() - 1);
+        return path.get(nextIndex);
+    }
+
+    private static boolean isTooFarFromPath(List<WorldPoint> path, WorldPoint currentLocation, int maxDistance) {
+        if (path == null || path.isEmpty()) {
+            return true;
+        }
+        int closestIndex = Rs2Walker.getClosestTileIndex(path);
+        WorldPoint closestPoint = path.get(closestIndex);
+        return currentLocation.distanceTo(closestPoint) > maxDistance;
+    }
+
+    private static void sleepRandom(long minMs, long maxMs) {
+        long delay = ThreadLocalRandom.current().nextLong(minMs, maxMs + 1);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public enum WalkerState {
+        ARRIVED,
+        UNREACHABLE
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/KSPAutoMinerConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/KSPAutoMinerConfig.java
@@ -35,4 +35,15 @@ public interface KSPAutoMinerConfig extends Config {
     default KSPAutoMinerRock rock() {
         return KSPAutoMinerRock.COPPER_TIN;
     }
+
+    @ConfigItem(
+            keyName = "enableAntiban",
+            name = "Enable Antiban",
+            description = "Use universal antiban settings",
+            position = 2,
+            section = generalSection
+    )
+    default boolean enableAntiban() {
+        return true;
+    }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/KSPAutoMinerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/KSPAutoMinerPlugin.java
@@ -22,7 +22,7 @@ import java.awt.AWTException;
 )
 @Slf4j
 public class KSPAutoMinerPlugin extends Plugin {
-    public static final String version = "1.0.4";
+    public static final String version = "1.0.7";
 
     @Inject
     private KSPAutoMinerConfig config;


### PR DESCRIPTION
### Motivation
- Fix a compilation failure caused by a missing `CustomWebWalker` referenced by the KSP Auto Miner script. 
- Provide users with control over universal antiban behavior so antiban templates and cooldowns can be enabled or disabled per preference. 
- Ensure antiban settings are applied and cleared consistently during the script lifecycle to avoid leaving global antiban state enabled.

### Description
- Added a KSP Auto Miner–scoped `CustomWebWalker` implementation at `src/main/java/net/runelite/client/plugins/microbot/KSPAutoMiner/CustomWebWalker.java` with `walkTo` overloads and a `WalkerState` enum.
- Updated `KSPAutoMinerScript` to call `CustomWebWalker.walkTo(...)` for pathing, to call `Rs2Antiban.resetAntibanSettings()` at startup and shutdown, and to gate `Rs2Antiban.actionCooldown()` / `Rs2Antiban.takeMicroBreakByChance()` behind `config.enableAntiban()`.
- Added `enableAntiban` config option to `KSPAutoMinerConfig` (default `true`) to toggle universal antiban behavior via `config.enableAntiban()`.
- Bumped the plugin version in `KSPAutoMinerPlugin` to `1.0.7`.

### Testing
- No automated tests were run; `./gradlew build` and `./gradlew test` were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982397abce08330a3db894b01d23631)