### PR TITLE
feat(ksp): progressive woodcutting locations, forestry interface, and axe handling (v0.1.5)

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterConfig.java
@@ -1,0 +1,170 @@
+package net.runelite.client.plugins.microbot.KSPAutoWoodcutter;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+@ConfigGroup("KSPAutoWoodcutter")
+public interface KSPAutoWoodcutterConfig extends Config {
+    String configGroup = "KSPAutoWoodcutter";
+
+    @ConfigSection(
+            name = "General",
+            description = "General settings",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigSection(
+            name = "Forestry",
+            description = "Forestry events",
+            position = 1,
+            closedByDefault = true
+    )
+    String forestrySection = "forestry";
+
+    @ConfigItem(
+            keyName = "mode",
+            name = "Mode",
+            description = "Select woodcutting mode",
+            position = 0,
+            section = generalSection
+    )
+    default KSPAutoWoodcutterMode mode() {
+        return KSPAutoWoodcutterMode.CHOP_DROP;
+    }
+
+    @ConfigItem(
+            keyName = "tree",
+            name = "Tree",
+            description = "Select which tree to chop (non-progressive modes)",
+            position = 1,
+            section = generalSection
+    )
+    default KSPAutoWoodcutterTree tree() {
+        return KSPAutoWoodcutterTree.TREE;
+    }
+
+    @ConfigItem(
+            keyName = "enableAntiban",
+            name = "Enable Antiban",
+            description = "Use universal antiban settings",
+            position = 2,
+            section = generalSection
+    )
+    default boolean enableAntiban() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "enableForestry",
+            name = "Enable forestry",
+            description = "Enable forestry features",
+            position = 0,
+            section = forestrySection
+    )
+    default boolean enableForestry() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "eggEvent",
+            name = "Enable Egg Event",
+            description = "Enable the Egg forestry event",
+            position = 1,
+            section = forestrySection
+    )
+    default boolean eggEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "entlingsEvent",
+            name = "Enable Entlings Event",
+            description = "Enable the Entlings forestry event",
+            position = 2,
+            section = forestrySection
+    )
+    default boolean entlingsEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "flowersEvent",
+            name = "Enable Flowers Event",
+            description = "Enable the Flowers forestry event",
+            position = 3,
+            section = forestrySection,
+            hidden = false
+    )
+    default boolean flowersEvent() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "foxEvent",
+            name = "Enable Fox Event",
+            description = "Enable the Fox forestry event",
+            position = 4,
+            section = forestrySection
+    )
+    default boolean foxEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "hivesEvent",
+            name = "Enable Hives Event",
+            description = "Enable the Hives forestry event",
+            position = 5,
+            section = forestrySection
+    )
+    default boolean hivesEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "leprechaunEvent",
+            name = "Enable Leprechaun Event",
+            description = "Enable the Leprechaun forestry event",
+            position = 6,
+            section = forestrySection
+    )
+    default boolean leprechaunEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "ritualEvent",
+            name = "Enable Ritual Event",
+            description = "Enable the Ritual forestry event",
+            position = 7,
+            section = forestrySection
+    )
+    default boolean ritualEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "rootEvent",
+            name = "Enable Root Event",
+            description = "Enable the Root forestry event",
+            position = 8,
+            section = forestrySection
+    )
+    default boolean rootEvent() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "saplingEvent",
+            name = "Enable Struggling Sapling Event",
+            description = "Enable the Struggling Sapling forestry event",
+            position = 9,
+            section = forestrySection
+    )
+    default boolean saplingEvent() {
+        return true;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterMode.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterMode.java
@@ -1,0 +1,28 @@
+package net.runelite.client.plugins.microbot.KSPAutoWoodcutter;
+
+public enum KSPAutoWoodcutterMode {
+    CHOP_DROP("Chop & Drop"),
+    CHOP_BURN("Chop & Burn"),
+    CHOP_BANK("Chop & Bank"),
+    PROGRESSIVE_BANK("Progressive Mode & Bank"),
+    PROGRESSIVE_DROP("Progressive Mode & Drop");
+
+    private final String displayName;
+
+    KSPAutoWoodcutterMode(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+
+    public boolean isBankingMode() {
+        return this == CHOP_BANK || this == PROGRESSIVE_BANK;
+    }
+
+    public boolean isProgressiveMode() {
+        return this == PROGRESSIVE_BANK || this == PROGRESSIVE_DROP;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterOverlay.java
@@ -1,0 +1,59 @@
+package net.runelite.client.plugins.microbot.KSPAutoWoodcutter;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.time.Duration;
+
+public class KSPAutoWoodcutterOverlay extends OverlayPanel {
+    @Inject
+    KSPAutoWoodcutterOverlay(KSPAutoWoodcutterPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_CENTER);
+    }
+
+    @Override
+    public Dimension render(java.awt.Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(230, 150));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("KSPAutoWoodcutter")
+                .color(Color.ORANGE)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Current Status:")
+                .right(KSPAutoWoodcutterScript.status)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Mode:")
+                .right(KSPAutoWoodcutterScript.modeLabel)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time running:")
+                .right(formatDuration(KSPAutoWoodcutterScript.getRuntime()))
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Logs Cut:")
+                .right(Integer.toString(KSPAutoWoodcutterScript.logsCut))
+                .build());
+
+        return super.render(graphics);
+    }
+
+    private String formatDuration(Duration duration) {
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterScript.java
@@ -1,0 +1,432 @@
+package net.runelite.client.plugins.microbot.KSPAutoWoodcutter;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GameObject;
+import net.runelite.api.Skill;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache;
+import net.runelite.client.plugins.microbot.api.tileobject.models.Rs2TileObjectModel;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.CustomWebWalker;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+@Slf4j
+public class KSPAutoWoodcutterScript extends Script {
+    private static final WorldPoint TREE_LOCATION = new WorldPoint(3160, 3453, 0);
+    private static final WorldPoint OAK_LOCATION = new WorldPoint(3192, 3459, 0);
+    private static final WorldPoint OAK_COMBAT_LOCATION = new WorldPoint(3099, 3243, 0);
+    private static final WorldPoint WILLOW_LOCATION = new WorldPoint(3086, 3233, 0);
+    private static final WorldPoint YEW_LOCATION = new WorldPoint(3085, 3475, 0);
+    private static final List<String> ALL_LOGS = Arrays.asList(
+            "Logs",
+            "Oak logs",
+            "Willow logs",
+            "Teak logs",
+            "Maple logs",
+            "Mahogany logs",
+            "Yew logs",
+            "Magic logs",
+            "Redwood logs"
+    );
+
+    private static final List<AxeRequirement> AXE_REQUIREMENTS = Arrays.asList(
+            new AxeRequirement(ItemID.BRONZE_AXE, 1, 1),
+            new AxeRequirement(ItemID.IRON_AXE, 1, 1),
+            new AxeRequirement(ItemID.STEEL_AXE, 6, 5),
+            new AxeRequirement(ItemID.BLACK_AXE, 11, 10),
+            new AxeRequirement(ItemID.MITHRIL_AXE, 21, 20),
+            new AxeRequirement(ItemID.ADAMANT_AXE, 31, 30),
+            new AxeRequirement(ItemID.RUNE_AXE, 41, 40),
+            new AxeRequirement(ItemID.DRAGON_AXE, 61, 60),
+            new AxeRequirement(ItemID.INFERNAL_AXE, 61, 60),
+            new AxeRequirement(ItemID.CRYSTAL_AXE, 71, 70)
+    );
+
+    public static String status = "Idle";
+    public static String modeLabel = "";
+    public static int logsCut = 0;
+
+    private static long startTimeMs;
+    private int lastInventoryCount;
+    private KSPAutoWoodcutterTree selectedTree;
+    private KSPAutoWoodcutterTree targetTree;
+    private WorldPoint targetLocation;
+
+    @Inject
+    private Rs2TileObjectCache rs2TileObjectCache;
+
+    public boolean run(KSPAutoWoodcutterConfig config) {
+        startTimeMs = System.currentTimeMillis();
+        logsCut = 0;
+        lastInventoryCount = 0;
+        status = "Starting";
+        modeLabel = config.mode().toString();
+        Rs2Antiban.resetAntibanSettings();
+        if (config.enableAntiban()) {
+            Rs2Antiban.antibanSetupTemplates.applyUniversalAntibanSetup();
+            Rs2AntibanSettings.actionCooldownChance = 0.2;
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) {
+                    return;
+                }
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (config.enableAntiban() && Rs2AntibanSettings.actionCooldownActive) {
+                    return;
+                }
+
+                KSPAutoWoodcutterMode mode = config.mode();
+                modeLabel = mode.toString();
+                updateTarget(mode, config.tree());
+                updateLogCount();
+
+                if (targetTree == null || targetLocation == null) {
+                    status = "No target tree";
+                    return;
+                }
+
+                if (!hasRequiredLevel(targetTree)) {
+                    status = "Woodcutting level too low";
+                    return;
+                }
+
+                if (Rs2Inventory.isFull()) {
+                    if (mode.isBankingMode()) {
+                        status = "Banking";
+                        if (!bankLogsAndUpgradeAxe(Rs2Player.getWorldLocation(), config.enableForestry())) {
+                            return;
+                        }
+                    } else if (mode == KSPAutoWoodcutterMode.CHOP_BURN) {
+                        status = "Burning logs";
+                        burnLogs();
+                    } else {
+                        status = "Dropping logs";
+                        dropLogs();
+                    }
+                    return;
+                }
+
+                if (Rs2Player.isAnimating()) {
+                    return;
+                }
+
+                if (Rs2Player.getWorldLocation().distanceTo(targetLocation) > 6) {
+                    status = "Walking to trees";
+                    CustomWebWalker.walkTo(targetLocation);
+                    return;
+                }
+
+                GameObject tree = findNearestTree(targetLocation, 12);
+                if (tree == null) {
+                    status = "No trees found";
+                    return;
+                }
+
+                status = "Chopping " + targetTree.toString();
+                if (Rs2GameObject.interact(tree)) {
+                    Rs2Player.waitForXpDrop(Skill.WOODCUTTING, true);
+                    if (config.enableAntiban()) {
+                        Rs2Antiban.actionCooldown();
+                        Rs2Antiban.takeMicroBreakByChance();
+                    }
+                }
+            } catch (Exception ex) {
+                Microbot.log("KSPAutoWoodcutter error: " + ex.getMessage());
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        status = "Stopped";
+        Rs2Antiban.resetAntibanSettings();
+    }
+
+    public static Duration getRuntime() {
+        if (startTimeMs == 0) {
+            return Duration.ZERO;
+        }
+        long elapsed = System.currentTimeMillis() - startTimeMs;
+        return Duration.ofMillis(elapsed);
+    }
+
+    private void updateTarget(KSPAutoWoodcutterMode mode, KSPAutoWoodcutterTree treeSelection) {
+        int woodcuttingLevel = Microbot.getClient().getRealSkillLevel(Skill.WOODCUTTING);
+        int combatLevel = Microbot.getClientThread().invoke(() -> {
+            if (Microbot.getClient().getLocalPlayer() == null) {
+                return 0;
+            }
+            return Microbot.getClient().getLocalPlayer().getCombatLevel();
+        });
+        KSPAutoWoodcutterTree previousTarget = targetTree;
+        WorldPoint previousLocation = targetLocation;
+        if (treeSelection != selectedTree) {
+            selectedTree = treeSelection;
+            resetLogCounters();
+        }
+
+        if (mode.isProgressiveMode()) {
+            if (woodcuttingLevel >= 60) {
+                targetTree = KSPAutoWoodcutterTree.YEW;
+                targetLocation = YEW_LOCATION;
+            } else if (woodcuttingLevel >= 30) {
+                targetTree = KSPAutoWoodcutterTree.WILLOW;
+                targetLocation = WILLOW_LOCATION;
+            } else if (woodcuttingLevel >= 15) {
+                targetTree = KSPAutoWoodcutterTree.OAK;
+                targetLocation = combatLevel >= 40 ? OAK_COMBAT_LOCATION : OAK_LOCATION;
+            } else {
+                targetTree = KSPAutoWoodcutterTree.TREE;
+                targetLocation = TREE_LOCATION;
+            }
+        } else {
+            targetTree = treeSelection != null ? treeSelection : KSPAutoWoodcutterTree.TREE;
+            targetLocation = Rs2Player.getWorldLocation();
+        }
+
+        if (previousTarget != targetTree || previousLocation != targetLocation) {
+            resetLogCounters();
+        }
+    }
+
+    private void updateLogCount() {
+        int currentCount = countRelevantLogs();
+        int delta = currentCount - lastInventoryCount;
+        if (delta > 0) {
+            logsCut += delta;
+        }
+        lastInventoryCount = currentCount;
+    }
+
+    private int countRelevantLogs() {
+        if (targetTree == null) {
+            return 0;
+        }
+        return Rs2Inventory.count(targetTree.getLogName());
+    }
+
+    private void resetLogCounters() {
+        lastInventoryCount = countRelevantLogs();
+    }
+
+    private boolean bankLogsAndUpgradeAxe(WorldPoint returnLocation, boolean enableForestry) {
+        if (!Rs2Bank.walkToBankAndUseBank()) {
+            return false;
+        }
+        if (!Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        Rs2Bank.depositAllExcept("axe");
+        equipForestryKitIfAvailable(enableForestry);
+        upgradeAxeIfAvailable();
+        ensureAxeAvailable();
+        Rs2Bank.closeBank();
+
+        if (returnLocation != null) {
+            CustomWebWalker.walkTo(returnLocation);
+        }
+        return true;
+    }
+
+    private void upgradeAxeIfAvailable() {
+        Rs2ItemModel bestFromBank = getBestAxeFromBank();
+        if (bestFromBank == null) {
+            return;
+        }
+
+        Rs2ItemModel currentAxe = getBestAxeOnPlayer();
+        int currentLevel = currentAxe != null ? getAxeWoodcuttingLevel(currentAxe.getId()) : 0;
+        int bankLevel = getAxeWoodcuttingLevel(bestFromBank.getId());
+
+        if (bankLevel <= currentLevel) {
+            return;
+        }
+
+        if (getAxeAttackLevel(bestFromBank.getId()) > 1) {
+            Rs2ItemModel currentWeapon = Rs2Equipment.get(EquipmentInventorySlot.WEAPON);
+            Rs2Bank.withdrawAndEquip(bestFromBank.getId());
+            if (currentWeapon != null && currentWeapon.getId() != bestFromBank.getId()) {
+                Rs2Bank.depositOne(currentWeapon.getId());
+            }
+        } else {
+            if (!Rs2Inventory.hasItem(bestFromBank.getId())) {
+                Rs2Bank.withdrawOne(bestFromBank.getId());
+            }
+        }
+
+        if (currentAxe != null && currentAxe.getId() != bestFromBank.getId()
+                && Rs2Inventory.hasItem(currentAxe.getId())) {
+            Rs2Bank.depositOne(currentAxe.getId());
+        }
+    }
+
+    private void ensureAxeAvailable() {
+        if (getBestAxeOnPlayer() != null) {
+            return;
+        }
+        Rs2ItemModel bestFromBank = getBestAxeFromBank();
+        if (bestFromBank == null) {
+            return;
+        }
+        Rs2Bank.withdrawOne(bestFromBank.getId());
+    }
+
+    private void equipForestryKitIfAvailable(boolean enableForestry) {
+        if (!enableForestry) {
+            return;
+        }
+        if (Rs2Equipment.isWearing(ItemID.FORESTRY_KIT)) {
+            return;
+        }
+        if (!Rs2Bank.hasItem(ItemID.FORESTRY_KIT)) {
+            return;
+        }
+        Rs2Bank.withdrawAndEquip(ItemID.FORESTRY_KIT);
+    }
+
+    private Rs2ItemModel getBestAxeOnPlayer() {
+        Rs2ItemModel equipped = Rs2Equipment.get(EquipmentInventorySlot.WEAPON);
+        if (equipped != null && isAxe(equipped.getId()) && canUseAxe(equipped.getId())) {
+            return equipped;
+        }
+
+        return Rs2Inventory.items()
+                .filter(item -> isAxe(item.getId()) && canUseAxe(item.getId()))
+                .max((first, second) -> Integer.compare(
+                        getAxeWoodcuttingLevel(first.getId()),
+                        getAxeWoodcuttingLevel(second.getId())))
+                .orElse(null);
+    }
+
+    private Rs2ItemModel getBestAxeFromBank() {
+        return Rs2Bank.getAll(item -> isAxe(item.getId()) && canUseAxe(item.getId()))
+                .max((first, second) -> Integer.compare(
+                        getAxeWoodcuttingLevel(first.getId()),
+                        getAxeWoodcuttingLevel(second.getId())))
+                .orElse(null);
+    }
+
+    private boolean canUseAxe(int itemId) {
+        AxeRequirement requirement = getAxeRequirement(itemId);
+        return requirement != null
+                && Rs2Player.getSkillRequirement(Skill.WOODCUTTING, requirement.woodcuttingLevel)
+                && Rs2Player.getSkillRequirement(Skill.ATTACK, requirement.attackLevel);
+    }
+
+    private boolean isAxe(int itemId) {
+        return getAxeRequirement(itemId) != null;
+    }
+
+    private int getAxeWoodcuttingLevel(int itemId) {
+        AxeRequirement requirement = getAxeRequirement(itemId);
+        return requirement != null ? requirement.woodcuttingLevel : 0;
+    }
+
+    private int getAxeAttackLevel(int itemId) {
+        AxeRequirement requirement = getAxeRequirement(itemId);
+        return requirement != null ? requirement.attackLevel : 0;
+    }
+
+    private AxeRequirement getAxeRequirement(int itemId) {
+        return AXE_REQUIREMENTS.stream()
+                .filter(requirement -> requirement.itemId == itemId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private GameObject findNearestTree(WorldPoint searchCenter, int radius) {
+        if (searchCenter == null || targetTree == null) {
+            return null;
+        }
+
+        return Rs2GameObject.getGameObjects(
+                        Rs2GameObject.nameMatches(targetTree.getObjectName(), false),
+                        searchCenter,
+                        radius)
+                .stream()
+                .filter(Rs2GameObject::isReachable)
+                .min((first, second) -> Integer.compare(
+                        first.getWorldLocation().distanceTo(Rs2Player.getWorldLocation()),
+                        second.getWorldLocation().distanceTo(Rs2Player.getWorldLocation())))
+                .orElse(null);
+    }
+
+    private void dropLogs() {
+        for (String log : ALL_LOGS) {
+            if (Rs2Inventory.hasItem(log, false)) {
+                Rs2Inventory.dropAll(log);
+            }
+        }
+    }
+
+    private void burnLogs() {
+        if (targetTree == null || !Rs2Inventory.hasItem(targetTree.getLogName())) {
+            return;
+        }
+
+        Rs2TileObjectModel campfire = findActiveCampfire();
+        if (campfire != null) {
+            Rs2Inventory.useItemOnObject(targetTree.getLogId(), campfire.getId());
+            Rs2Player.waitForXpDrop(Skill.FIREMAKING, true);
+            return;
+        }
+
+        if (!Rs2Inventory.hasItem("Tinderbox")) {
+            status = "Missing tinderbox";
+            return;
+        }
+
+        Rs2Inventory.use("Tinderbox");
+        Rs2Inventory.use(targetTree.getLogName());
+        Rs2Player.waitForXpDrop(Skill.FIREMAKING, true);
+    }
+
+    private Rs2TileObjectModel findActiveCampfire() {
+        Rs2TileObjectModel campfire = rs2TileObjectCache.query().where(tile -> tile.getId() == 49927).nearest(6);
+        if (campfire != null) {
+            return campfire;
+        }
+        return rs2TileObjectCache.query().where(tile -> tile.getId() == 26185).nearest(6);
+    }
+
+    private boolean hasRequiredLevel(KSPAutoWoodcutterTree tree) {
+        return Microbot.getClient().getRealSkillLevel(Skill.WOODCUTTING) >= tree.getWoodcuttingLevel();
+    }
+
+    private static final class AxeRequirement {
+        private final int itemId;
+        private final int woodcuttingLevel;
+        private final int attackLevel;
+
+        private AxeRequirement(int itemId, int woodcuttingLevel, int attackLevel) {
+            this.itemId = itemId;
+            this.woodcuttingLevel = woodcuttingLevel;
+            this.attackLevel = attackLevel;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterTree.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAutoWoodcutter/KSPAutoWoodcutterTree.java
@@ -1,0 +1,71 @@
+package net.runelite.client.plugins.microbot.KSPAutoWoodcutter;
+
+import net.runelite.api.gameval.ItemID;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public enum KSPAutoWoodcutterTree {
+    TREE("Tree", "Logs", ItemID.LOGS, 1),
+    OAK("Oak", "Oak logs", ItemID.OAK_LOGS, 15),
+    WILLOW("Willow", "Willow logs", ItemID.WILLOW_LOGS, 30),
+    TEAK("Teak", "Teak logs", ItemID.TEAK_LOGS, 35),
+    MAPLE("Maple tree", "Maple logs", ItemID.MAPLE_LOGS, 45),
+    MAHOGANY("Mahogany", "Mahogany logs", ItemID.MAHOGANY_LOGS, 50),
+    YEW("Yew", "Yew logs", ItemID.YEW_LOGS, 60),
+    MAGIC("Magic tree", "Magic logs", ItemID.MAGIC_LOGS, 75),
+    REDWOOD("Redwood", "Redwood logs", ItemID.REDWOOD_LOGS, 90);
+
+    private static final List<KSPAutoWoodcutterTree> PROGRESSIVE_ORDER = Arrays.asList(
+            TREE,
+            OAK,
+            WILLOW,
+            TEAK,
+            MAPLE,
+            MAHOGANY,
+            YEW,
+            MAGIC,
+            REDWOOD
+    );
+
+    private final String objectName;
+    private final String logName;
+    private final int logId;
+    private final int woodcuttingLevel;
+
+    KSPAutoWoodcutterTree(String objectName, String logName, int logId, int woodcuttingLevel) {
+        this.objectName = objectName;
+        this.logName = logName;
+        this.logId = logId;
+        this.woodcuttingLevel = woodcuttingLevel;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public String getLogName() {
+        return logName;
+    }
+
+    public int getLogId() {
+        return logId;
+    }
+
+    public int getWoodcuttingLevel() {
+        return woodcuttingLevel;
+    }
+
+    public static KSPAutoWoodcutterTree resolveForLevel(int woodcuttingLevel) {
+        return PROGRESSIVE_ORDER.stream()
+                .filter(tree -> woodcuttingLevel >= tree.woodcuttingLevel)
+                .max(Comparator.comparingInt(KSPAutoWoodcutterTree::getWoodcuttingLevel))
+                .orElse(TREE);
+    }
+
+    @Override
+    public String toString() {
+        return objectName.replace(" tree", "");
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EggEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EggEvent.java
@@ -13,7 +13,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 import net.runelite.client.plugins.microbot.woodcutting.enums.WoodcuttingTree;
 
@@ -24,15 +24,15 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Slf4j
 public class EggEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
-    public EggEvent(AutoWoodcuttingPlugin plugin) {
+    private final ForestryEventPlugin plugin;
+    public EggEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             var forester = Rs2Npc
                     .getNpcs(NpcID.GATHERING_EVENT_PHEASANT_FORESTER)
@@ -56,7 +56,7 @@ public class EggEvent implements BlockingEvent {
             return true; // If the forester is not found, we cannot proceed with the event
         }
 
-        plugin.currentForestryEvent = ForestryEvents.PHEASANT;
+        plugin.setCurrentForestryEvent(ForestryEvents.PHEASANT);
 
         //if inventory is full, we cannot proceed with the event
         if (Rs2Inventory.isFull()) {

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EntlingsEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/EntlingsEvent.java
@@ -9,7 +9,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 
 import java.util.Comparator;
@@ -17,15 +17,15 @@ import java.util.stream.Collectors;
 @Slf4j
 public class EntlingsEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
-    public EntlingsEvent(AutoWoodcuttingPlugin plugin) {
+    private final ForestryEventPlugin plugin;
+    public EntlingsEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             var entlings = Rs2Npc.getNpcs(npc -> npc.getId() == NpcID.GATHERING_EVENT_ENTLINGS_NPC_01)
             .collect(Collectors.toList());
@@ -39,7 +39,7 @@ public class EntlingsEvent implements BlockingEvent {
     @Override
     public boolean execute() {
         Microbot.log("EntlingsEvent: Starting Entlings event execution");
-        plugin.currentForestryEvent = ForestryEvents.ENTLING;
+        plugin.setCurrentForestryEvent(ForestryEvents.ENTLING);
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         
         // ensure inventory space for tree leaves and potential egg nest (20% chance)

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/FlowersEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/FlowersEvent.java
@@ -8,7 +8,7 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 
 import java.util.stream.Collectors;
@@ -17,15 +17,15 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Slf4j
 public class FlowersEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
-    public FlowersEvent(AutoWoodcuttingPlugin plugin) {
+    private final ForestryEventPlugin plugin;
+    public FlowersEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             var flowers = Rs2Npc.getNpcs(npc ->
                     npc.getName() != null && isFloweringBush(npc.getId())
@@ -39,7 +39,7 @@ public class FlowersEvent implements BlockingEvent {
 
     @Override
     public boolean execute() {
-        plugin.currentForestryEvent = ForestryEvents.FLOWERING_TREE;
+        plugin.setCurrentForestryEvent(ForestryEvents.FLOWERING_TREE);
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         
         // ensure inventory space for strange pollen and fruits/seeds

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/FoxEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/FoxEvent.java
@@ -8,22 +8,22 @@ import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 import org.slf4j.event.Level;
 
 @Slf4j
 public class FoxEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
-    public FoxEvent(AutoWoodcuttingPlugin plugin) {
+    private final ForestryEventPlugin plugin;
+    public FoxEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             var outDoorFox = Rs2Npc.getNpc(NpcID.GATHERING_EVENT_POACHERS_FOX_OUTDOORS);
             var indoorFox = Rs2Npc.getNpc(NpcID.GATHERING_EVENT_POACHERS_FOX_INDOORS);
@@ -37,7 +37,7 @@ public class FoxEvent implements BlockingEvent {
     @Override
     public boolean execute() {
         Microbot.log("FoxEvent: Executing Fox event");
-        plugin.currentForestryEvent = ForestryEvents.FOX_TRAP;
+        plugin.setCurrentForestryEvent(ForestryEvents.FOX_TRAP);
         Rs2Walker.setTarget(null); // stop walking
         
         // ensure inventory space for potential fox whistle (1/30 chance)

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/HivesEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/HivesEvent.java
@@ -12,7 +12,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 import net.runelite.client.plugins.microbot.woodcutting.enums.WoodcuttingTree;
 
@@ -26,19 +26,19 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Slf4j
 public class HivesEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
+    private final ForestryEventPlugin plugin;
     private final Set<Integer> completedBeehives = new HashSet<>();
     private Rs2NpcModel currentBeehive = null;
     private int initialLogCount = -1;
     
-    public HivesEvent(AutoWoodcuttingPlugin plugin) {
+    public HivesEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             var beehives = Rs2Npc.getNpcs(x -> x.getId() == net.runelite.api.gameval.NpcID.GATHERING_EVENT_BEES_BEEBOX_1 || x.getId() == net.runelite.api.gameval.NpcID.GATHERING_EVENT_BEES_BEEBOX_2);
             WoodcuttingTree tree = plugin.getSelectedTree();
@@ -51,7 +51,7 @@ public class HivesEvent implements BlockingEvent {
 
     @Override
     public boolean execute() {
-        plugin.currentForestryEvent = ForestryEvents.BEE_HIVE;
+        plugin.setCurrentForestryEvent(ForestryEvents.BEE_HIVE);
         completedBeehives.clear();
         WoodcuttingTree tree = plugin.getSelectedTree();
         initialLogCount = tree == null ? 0 : Rs2Inventory.count(tree.getLogID());

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/LeprechaunEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/LeprechaunEvent.java
@@ -12,7 +12,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 import org.slf4j.event.Level;
 
@@ -23,16 +23,16 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepGaussian;
 @Slf4j
 public class LeprechaunEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
+    private final ForestryEventPlugin plugin;
 
-    public LeprechaunEvent(AutoWoodcuttingPlugin plugin) {
+    public LeprechaunEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             Optional<Rs2NpcModel> leprechaun =  Rs2Npc
                     .getNpcs(NpcID.GATHERING_EVENT_WOODCUTTING_LEPRECHAUN)
@@ -47,7 +47,7 @@ public class LeprechaunEvent implements BlockingEvent {
     @Override
     public boolean execute() {
         Microbot.log("LeprechaunEvent: Executing Leprechaun event");
-        plugin.currentForestryEvent = ForestryEvents.RAINBOW;
+        plugin.setCurrentForestryEvent(ForestryEvents.RAINBOW);
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         while (this.validate()) {
             log.info("LeprechaunEvent: Leprechaun event still valid, continuing execution get opbject");

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RitualEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RitualEvent.java
@@ -9,7 +9,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 import org.slf4j.event.Level;
 
@@ -23,16 +23,16 @@ import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Slf4j
 public class RitualEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
+    private final ForestryEventPlugin plugin;
 
-    public RitualEvent(AutoWoodcuttingPlugin plugin) {
+    public RitualEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
             Optional<Rs2NpcModel> dryadCache = Rs2Npc
                     .getNpcs(NpcID.GATHERING_EVENT_ENCHANTED_RITUAL_DRYAD)
@@ -47,7 +47,7 @@ public class RitualEvent implements BlockingEvent {
 
     @Override
     public boolean execute() {
-        plugin.currentForestryEvent = ForestryEvents.RITUAL_CIRCLES;
+        plugin.setCurrentForestryEvent(ForestryEvents.RITUAL_CIRCLES);
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         
         // ensure inventory space for potential petal garland (1/30 chance)
@@ -57,7 +57,7 @@ public class RitualEvent implements BlockingEvent {
         }
         
         while (this.validate()) {
-            var targetCircle = this.solveCircles(plugin.ritualCircles);
+            var targetCircle = this.solveCircles(plugin.getRitualCircles());
             if (targetCircle == null) {
                 Microbot.log("RitualEvent: No target circle found, cannot proceed with the ritual.", Level.INFO);
                 sleepGaussian(600, 150);

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RootEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/RootEvent.java
@@ -12,25 +12,25 @@ import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 
 import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
 @Slf4j
 public class RootEvent implements BlockingEvent {
 
-    private final AutoWoodcuttingPlugin plugin;
-    public RootEvent(AutoWoodcuttingPlugin plugin) {
+    private final ForestryEventPlugin plugin;
+    public RootEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;
-            var root = plugin.rs2TileObjectCache.query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS).nearest();
-            var specialRoot = plugin.rs2TileObjectCache.query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS_SPECIAL).nearest();
+            var root = plugin.getTileObjectCache().query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS).nearest();
+            var specialRoot = plugin.getTileObjectCache().query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS_SPECIAL).nearest();
 
             // Is the hasAction Check needed?
             // If special root is present
@@ -51,11 +51,11 @@ public class RootEvent implements BlockingEvent {
     @Override
     public boolean execute() {
         Microbot.log("RootEvent: Executing Root event");
-        plugin.currentForestryEvent = ForestryEvents.TREE_ROOT;
+        plugin.setCurrentForestryEvent(ForestryEvents.TREE_ROOT);
         Rs2Walker.setTarget(null); // stop walking, stop moving to bank for example
         while (this.validate()) {
-            var root = plugin.rs2TileObjectCache.query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS).nearest();
-            var specialRoot = plugin.rs2TileObjectCache.query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS_SPECIAL).nearest();
+            var root = plugin.getTileObjectCache().query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS).nearest();
+            var specialRoot = plugin.getTileObjectCache().query().where(x -> x.getId() == ObjectID.GATHERING_EVENT_RISING_ROOTS_SPECIAL).nearest();
 
             // Use special attack if available
             if ( Rs2Equipment.isWearing(ItemID.DRAGON_AXE) || Rs2Equipment.isWearing(ItemID.DRAGON_AXE_2H) || Rs2Equipment.isWearing(ItemID.CRYSTAL_AXE) ||

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/Forestry/StrugglingSaplingEvent.java
@@ -10,7 +10,7 @@ import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
-import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingPlugin;
+import net.runelite.client.plugins.microbot.woodcutting.ForestryEventPlugin;
 import net.runelite.client.plugins.microbot.woodcutting.AutoWoodcuttingScript;
 import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
 
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import static net.runelite.api.gameval.ObjectID.*;
 @Slf4j
 public class StrugglingSaplingEvent implements BlockingEvent {
-    private final AutoWoodcuttingPlugin plugin;
+    private final ForestryEventPlugin plugin;
     private final List<Integer> ingredientIds = List.of(
         GATHERING_EVENT_SAPLING_INGREDIENT_1,
         GATHERING_EVENT_SAPLING_INGREDIENT_2,
@@ -34,14 +34,14 @@ public class StrugglingSaplingEvent implements BlockingEvent {
         GATHERING_EVENT_SAPLING_INGREDIENT_5
     );
 
-    public StrugglingSaplingEvent(AutoWoodcuttingPlugin plugin) {
+    public StrugglingSaplingEvent(ForestryEventPlugin plugin) {
         this.plugin = plugin;
     }
 
     @Override
     public boolean validate() {
         try{
-            if (plugin == null || !Microbot.isPluginEnabled(plugin)) return false;
+            if (plugin == null || !plugin.isEnabled()) return false;
             if (Microbot.getClient() == null || !Microbot.isLoggedIn()) return false;        
             var strugglingSaplings = Rs2GameObject.getGameObjects(Rs2GameObject.nameMatches("Struggling sapling", false));
             if (strugglingSaplings == null) return false;
@@ -60,7 +60,7 @@ public class StrugglingSaplingEvent implements BlockingEvent {
     public boolean execute() {
         try {
             Microbot.log("StrugglingSaplingEvent: Executing Struggling Sapling event");
-            plugin.currentForestryEvent = ForestryEvents.STRUGGLING_SAPLING;
+            plugin.setCurrentForestryEvent(ForestryEvents.STRUGGLING_SAPLING);
             // Find the struggling sapling
             var sapling = Rs2GameObject.getGameObjects(Rs2GameObject.nameMatches("Struggling sapling", false))
                     .stream()
@@ -112,7 +112,7 @@ public class StrugglingSaplingEvent implements BlockingEvent {
                 } else {
                     stage = 0;
                 }
-                var correctIngredient = plugin.saplingOrder[stage];
+                var correctIngredient = plugin.getSaplingOrder()[stage];
 
                 if (correctIngredient != null) {
                     // Look for matching ingredient in our available ingredients
@@ -150,9 +150,9 @@ public class StrugglingSaplingEvent implements BlockingEvent {
             }
 
             Microbot.log("StrugglingSaplingEvent: Finished processing struggling sapling.");
-            plugin.saplingOrder[0] = null; // Reset the sapling order after processing
-            plugin.saplingOrder[1] = null;
-            plugin.saplingOrder[2] = null;
+            plugin.getSaplingOrder()[0] = null; // Reset the sapling order after processing
+            plugin.getSaplingOrder()[1] = null;
+            plugin.getSaplingOrder()[2] = null;
             plugin.incrementForestryEventCompleted();
             return true;
         }

--- a/src/main/java/net/runelite/client/plugins/microbot/woodcutting/ForestryEventPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/woodcutting/ForestryEventPlugin.java
@@ -1,0 +1,31 @@
+package net.runelite.client.plugins.microbot.woodcutting;
+
+import net.runelite.api.GameObject;
+import net.runelite.client.plugins.microbot.api.tileobject.Rs2TileObjectCache;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.woodcutting.enums.ForestryEvents;
+import net.runelite.client.plugins.microbot.woodcutting.enums.WoodcuttingTree;
+
+import java.util.List;
+
+public interface ForestryEventPlugin {
+    boolean isEnabled();
+
+    void setCurrentForestryEvent(ForestryEvents event);
+
+    ForestryEvents getCurrentForestryEvent();
+
+    WoodcuttingTree getSelectedTree();
+
+    boolean ensureInventorySpace(int requiredSlots);
+
+    void incrementForestryEventCompleted();
+
+    List<Rs2NpcModel> getRitualCircles();
+
+    GameObject[] getSaplingOrder();
+
+    List<GameObject> getSaplingIngredients();
+
+    Rs2TileObjectCache getTileObjectCache();
+}


### PR DESCRIPTION
### Motivation
- Add a KSP-targeted Auto Woodcutter with progressive modes and map locations so the bot selects appropriate trees by woodcutting/combat level and walks to those spots. 
- Ensure the bot always has an axe after banking and can upgrade/withdraw axes from the bank so woodcutting does not stall. 
- Unify forestry event handling so multiple woodcutting plugins can share the same event handlers and logic.

### Description
- Added a new `KSPAutoWoodcutter` plugin with `KSPAutoWoodcutterConfig`, `KSPAutoWoodcutterMode`, `KSPAutoWoodcutterOverlay`, `KSPAutoWoodcutterPlugin`, `KSPAutoWoodcutterScript`, and `KSPAutoWoodcutterTree`; bumped plugin `version` to `0.1.5` in `KSPAutoWoodcutterPlugin` and wired the overlay and script into lifecycle methods. 
- Implemented progressive tree selection and walking logic in `KSPAutoWoodcutterScript` using new location constants (`TREE_LOCATION`, `OAK_LOCATION`, `OAK_COMBAT_LOCATION`, `WILLOW_LOCATION`, `YEW_LOCATION`) and selecting oak location based on combat level; the script now walks to `targetLocation` and finds/interacts with nearest tree around that point. 
- Implemented banking/axe handling in the KSP plugin: `bankLogsAndUpgradeAxe(...)`, `upgradeAxeIfAvailable()`, `ensureAxeAvailable()`, and related helpers to withdraw/equip the best usable axe and equip a forestry kit when configured. 
- Introduced a `ForestryEventPlugin` interface and updated forestry event classes (`EggEvent`, `EntlingsEvent`, `FlowersEvent`, `FoxEvent`, `HivesEvent`, `LeprechaunEvent`, `RitualEvent`, `RootEvent`, `StrugglingSaplingEvent`) to depend on the interface rather than a concrete plugin class and to call `plugin.isEnabled()`, `plugin.setCurrentForestryEvent(...)`, and other interface methods. 
- Updated `AutoWoodcuttingPlugin` to implement `ForestryEventPlugin` and expose required methods (`getRitualCircles()`, `getSaplingOrder()`, `getSaplingIngredients()`, `getTileObjectCache()`, `ensureInventorySpace(...)`, etc.) so forestry event code can be reused across plugins.

### Testing
- No automated tests were executed: `./gradlew test` was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826374a79c8330ba2b5e5e90c885d4)