### PR TITLE
feat(actionbars): configurable multi-bar actions, hotkeys and draggable overlay

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsAction.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsAction.java
@@ -1,0 +1,92 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2Prayer;
+import net.runelite.client.plugins.microbot.util.prayer.Rs2PrayerEnum;
+
+public class ActionbarsAction {
+    private final ActionbarsActionType type;
+    private final String payload;
+
+    public ActionbarsAction(ActionbarsActionType type, String payload) {
+        this.type = type == null ? ActionbarsActionType.NONE : type;
+        this.payload = payload == null ? "" : payload.trim();
+    }
+
+    public ActionbarsActionType getType() {
+        return type;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public String getFallbackLabel() {
+        switch (type) {
+            case EAT_FOOD:
+                return "Eat";
+            case EAT_FAST_FOOD:
+                return "Fast Eat";
+            case DRINK_PRAYER_POTION:
+                return "Prayer";
+            case TOGGLE_SPEC:
+                return "Spec";
+            case TOGGLE_PRAYER:
+                return payload.isBlank() ? "Prayer" : payload.replace('_', ' ');
+            default:
+                return "";
+        }
+    }
+
+    public void execute() {
+        switch (type) {
+            case EAT_FOOD:
+                Microbot.getClientThread().runOnSeperateThread(() -> {
+                    Rs2Player.useFood();
+                    return null;
+                });
+                break;
+            case EAT_FAST_FOOD:
+                Microbot.getClientThread().runOnSeperateThread(() -> {
+                    Rs2Player.useFastFood();
+                    return null;
+                });
+                break;
+            case DRINK_PRAYER_POTION:
+                Microbot.getClientThread().runOnSeperateThread(() -> {
+                    Rs2Player.drinkPrayerPotion();
+                    return null;
+                });
+                break;
+            case TOGGLE_SPEC:
+                Microbot.getClientThread().runOnSeperateThread(() -> {
+                    Rs2Combat.setSpecState(!Rs2Combat.getSpecState());
+                    return null;
+                });
+                break;
+            case TOGGLE_PRAYER:
+                Rs2PrayerEnum prayer = resolvePrayer();
+                if (prayer != null) {
+                    Rs2Prayer.toggle(prayer);
+                }
+                break;
+            case NONE:
+            default:
+                break;
+        }
+    }
+
+    private Rs2PrayerEnum resolvePrayer() {
+        if (payload.isBlank()) {
+            return null;
+        }
+        String normalized = payload.trim().toUpperCase().replace(' ', '_').replace('-', '_');
+        try {
+            return Rs2PrayerEnum.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsActionType.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsActionType.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+public enum ActionbarsActionType {
+    NONE,
+    EAT_FOOD,
+    EAT_FAST_FOOD,
+    DRINK_PRAYER_POTION,
+    TOGGLE_SPEC,
+    TOGGLE_PRAYER;
+
+    public static ActionbarsActionType from(String value) {
+        if (value == null || value.isBlank()) {
+            return NONE;
+        }
+        try {
+            return ActionbarsActionType.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return NONE;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsBar.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsBar.java
@@ -1,0 +1,23 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ActionbarsBar {
+    private final List<ActionbarsSlot> slots;
+
+    public ActionbarsBar(List<ActionbarsSlot> slots) {
+        this.slots = slots == null ? Collections.emptyList() : Collections.unmodifiableList(slots);
+    }
+
+    public List<ActionbarsSlot> getSlots() {
+        return slots;
+    }
+
+    public ActionbarsSlot getSlot(int index) {
+        if (index < 0 || index >= slots.size()) {
+            return null;
+        }
+        return slots.get(index);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsConfig.java
@@ -1,0 +1,66 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Keybind;
+
+@ConfigGroup("actionbars")
+public interface ActionbarsConfig extends Config {
+    @ConfigSection(
+            name = "Action Bars",
+            description = "Configure action bars and hotkeys",
+            position = 0
+    )
+    String actionBarsSection = "actionBarsSection";
+
+    @ConfigItem(
+            keyName = "activeBarIndex",
+            name = "Active bar (1-based)",
+            description = "Which action bar line is active",
+            position = 0,
+            section = actionBarsSection
+    )
+    default int activeBarIndex() {
+        return 1;
+    }
+
+    @ConfigItem(
+            keyName = "nextBarHotkey",
+            name = "Next bar hotkey",
+            description = "Switch to the next action bar",
+            position = 1,
+            section = actionBarsSection
+    )
+    default Keybind nextBarHotkey() {
+        return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(
+            keyName = "previousBarHotkey",
+            name = "Previous bar hotkey",
+            description = "Switch to the previous action bar",
+            position = 2,
+            section = actionBarsSection
+    )
+    default Keybind previousBarHotkey() {
+        return Keybind.NOT_SET;
+    }
+
+    @ConfigItem(
+            keyName = "actionBars",
+            name = "Action bar definitions",
+            description = "One bar per line. Each line has 12 slots separated by |. Each slot is label=TYPE "
+                    + "or label=TYPE:payload. Types: NONE, EAT_FOOD, EAT_FAST_FOOD, DRINK_PRAYER_POTION, "
+                    + "TOGGLE_SPEC, TOGGLE_PRAYER. Example: Eat=EAT_FOOD|Spec=TOGGLE_SPEC|Piety=TOGGLE_PRAYER:PIETY",
+            position = 3,
+            section = actionBarsSection
+    )
+    default String actionBars() {
+        return "Eat=EAT_FOOD|Spec=TOGGLE_SPEC|Piety=TOGGLE_PRAYER:PIETY|Protect=TOGGLE_PRAYER:PROTECT_MELEE"
+                + "|Range=TOGGLE_PRAYER:PROTECT_RANGE|Mage=TOGGLE_PRAYER:PROTECT_MAGIC"
+                + "|Quick=TOGGLE_PRAYER:THICK_SKIN|Food=EAT_FAST_FOOD|Drink=DRINK_PRAYER_POTION"
+                + "|---=NONE|---=NONE|---=NONE";
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsDefinitions.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsDefinitions.java
@@ -1,0 +1,95 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import net.runelite.client.plugins.microbot.Microbot;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class ActionbarsDefinitions {
+    public static final int SLOT_COUNT = 12;
+
+    private ActionbarsDefinitions() {
+    }
+
+    public static List<ActionbarsBar> parseBars(String raw) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return Collections.singletonList(defaultBar());
+        }
+
+        String[] lines = raw.split("\\r?\\n");
+        List<ActionbarsBar> bars = new ArrayList<>();
+        for (String line : lines) {
+            if (line == null || line.trim().isEmpty()) {
+                continue;
+            }
+            bars.add(parseBar(line));
+        }
+        if (bars.isEmpty()) {
+            bars.add(defaultBar());
+        }
+        return bars;
+    }
+
+    public static ActionbarsBar resolveActiveBar(String raw, int activeIndex) {
+        List<ActionbarsBar> bars = parseBars(raw);
+        int clampedIndex = clampActiveIndex(bars, activeIndex);
+        return bars.get(clampedIndex - 1);
+    }
+
+    public static int clampActiveIndex(List<ActionbarsBar> bars, int activeIndex) {
+        int totalBars = bars == null || bars.isEmpty() ? 1 : bars.size();
+        int index = activeIndex < 1 ? 1 : Math.min(activeIndex, totalBars);
+        return index;
+    }
+
+    public static void updateActiveBarIndex(int nextIndex) {
+        Microbot.getConfigManager().setConfiguration("actionbars", "activeBarIndex", nextIndex);
+    }
+
+    private static ActionbarsBar parseBar(String line) {
+        String[] slots = line.split("\\|");
+        List<ActionbarsSlot> parsedSlots = new ArrayList<>();
+        for (int i = 0; i < SLOT_COUNT; i++) {
+            if (i < slots.length) {
+                parsedSlots.add(parseSlot(slots[i]));
+            } else {
+                parsedSlots.add(new ActionbarsSlot("", new ActionbarsAction(ActionbarsActionType.NONE, "")));
+            }
+        }
+        return new ActionbarsBar(parsedSlots);
+    }
+
+    private static ActionbarsSlot parseSlot(String slotText) {
+        if (slotText == null || slotText.trim().isEmpty()) {
+            return new ActionbarsSlot("", new ActionbarsAction(ActionbarsActionType.NONE, ""));
+        }
+        String trimmed = slotText.trim();
+        String label = "";
+        String actionDefinition = trimmed;
+        int labelIndex = trimmed.indexOf('=');
+        if (labelIndex >= 0) {
+            label = trimmed.substring(0, labelIndex).trim();
+            actionDefinition = trimmed.substring(labelIndex + 1).trim();
+        }
+
+        String actionName = actionDefinition;
+        String payload = "";
+        int payloadIndex = actionDefinition.indexOf(':');
+        if (payloadIndex >= 0) {
+            actionName = actionDefinition.substring(0, payloadIndex);
+            payload = actionDefinition.substring(payloadIndex + 1);
+        }
+
+        ActionbarsActionType type = ActionbarsActionType.from(actionName);
+        return new ActionbarsSlot(label, new ActionbarsAction(type, payload));
+    }
+
+    private static ActionbarsBar defaultBar() {
+        List<ActionbarsSlot> slots = new ArrayList<>();
+        for (int i = 0; i < SLOT_COUNT; i++) {
+            slots.add(new ActionbarsSlot("", new ActionbarsAction(ActionbarsActionType.NONE, "")));
+        }
+        return new ActionbarsBar(slots);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsOverlay.java
@@ -1,0 +1,155 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+
+import javax.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GradientPaint;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.RoundRectangle2D;
+import java.util.List;
+
+public class ActionbarsOverlay extends Overlay {
+    private static final int SLOT_SIZE = 32;
+    private static final int SLOT_GAP = 6;
+    private static final int BAR_PADDING = 10;
+    private static final int BAR_CORNER_RADIUS = 16;
+    private static final int LABEL_HEIGHT = 12;
+    private static final int BOTTOM_MARGIN = 48;
+    private static final String[] KEY_LABELS = {
+            "1", "2", "3", "4", "5", "6",
+            "7", "8", "9", "0", "-", "="
+    };
+
+    private final Client client;
+    private final ActionbarsConfig config;
+
+    @Inject
+    public ActionbarsOverlay(Client client, ActionbarsConfig config) {
+        this.client = client;
+        this.config = config;
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setPriority(OverlayPriority.LOW);
+        setMovable(true);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        int canvasWidth = client.getCanvasWidth();
+        int canvasHeight = client.getCanvasHeight();
+        if (canvasWidth <= 0 || canvasHeight <= 0) {
+            return null;
+        }
+
+        int barWidth = ActionbarsDefinitions.SLOT_COUNT * SLOT_SIZE
+                + (ActionbarsDefinitions.SLOT_COUNT - 1) * SLOT_GAP + BAR_PADDING * 2;
+        int barHeight = SLOT_SIZE + BAR_PADDING * 2 + LABEL_HEIGHT;
+        int x = Math.max(0, (canvasWidth - barWidth) / 2);
+        int y = Math.max(0, canvasHeight - barHeight - BOTTOM_MARGIN);
+
+        List<ActionbarsBar> bars = ActionbarsDefinitions.parseBars(config.actionBars());
+        int activeIndex = ActionbarsDefinitions.clampActiveIndex(bars, config.activeBarIndex());
+        ActionbarsBar activeBar = bars.get(activeIndex - 1);
+
+        Object antialiasing = graphics.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+        Object textAntialiasing = graphics.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+        Shape barShape = new RoundRectangle2D.Float(x, y, barWidth, barHeight, BAR_CORNER_RADIUS, BAR_CORNER_RADIUS);
+        GradientPaint barGradient = new GradientPaint(
+                x,
+                y,
+                new Color(20, 23, 28, 230),
+                x,
+                y + barHeight,
+                new Color(6, 8, 12, 230)
+        );
+        graphics.setPaint(barGradient);
+        graphics.fill(barShape);
+        graphics.setColor(new Color(90, 96, 104, 200));
+        graphics.setStroke(new BasicStroke(1.4f));
+        graphics.draw(barShape);
+
+        int slotY = y + BAR_PADDING;
+        int slotX = x + BAR_PADDING;
+        Font prevFont = graphics.getFont();
+        graphics.setFont(new Font("SansSerif", Font.PLAIN, 10));
+        for (int i = 0; i < ActionbarsDefinitions.SLOT_COUNT; i++) {
+            int currentX = slotX + i * (SLOT_SIZE + SLOT_GAP);
+            drawSlot(graphics, currentX, slotY, SLOT_SIZE, SLOT_SIZE);
+            ActionbarsSlot slot = activeBar.getSlot(i);
+            String label = slot == null ? "" : slot.getLabel();
+            if (label.isBlank() && slot != null) {
+                label = slot.getAction().getFallbackLabel();
+            }
+            drawSlotLabel(graphics, currentX, slotY + SLOT_SIZE - 10, label);
+            drawKeyLabel(graphics, currentX, slotY + SLOT_SIZE + LABEL_HEIGHT - 2, KEY_LABELS[i]);
+        }
+        drawBarIndicator(graphics, x + 8, y + 14, activeIndex, bars.size());
+        graphics.setFont(prevFont);
+
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, antialiasing);
+        graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, textAntialiasing);
+        return new Dimension(barWidth, barHeight);
+    }
+
+    private void drawSlot(Graphics2D graphics, int x, int y, int width, int height) {
+        Shape slotShape = new RoundRectangle2D.Float(x, y, width, height, 8, 8);
+        GradientPaint slotGradient = new GradientPaint(
+                x,
+                y,
+                new Color(54, 60, 70, 220),
+                x,
+                y + height,
+                new Color(24, 28, 34, 220)
+        );
+        graphics.setPaint(slotGradient);
+        graphics.fill(slotShape);
+
+        graphics.setColor(new Color(140, 148, 160, 200));
+        graphics.setStroke(new BasicStroke(1.1f));
+        graphics.draw(slotShape);
+
+        graphics.setColor(new Color(255, 255, 255, 25));
+        graphics.drawLine(x + 3, y + 4, x + width - 4, y + 4);
+    }
+
+    private void drawKeyLabel(Graphics2D graphics, int centerX, int baselineY, String label) {
+        int textWidth = graphics.getFontMetrics().stringWidth(label);
+        int textX = centerX + (SLOT_SIZE - textWidth) / 2;
+        graphics.setColor(new Color(205, 210, 220, 200));
+        graphics.drawString(label, textX, baselineY);
+    }
+
+    private void drawSlotLabel(Graphics2D graphics, int centerX, int baselineY, String label) {
+        if (label == null || label.isBlank()) {
+            return;
+        }
+        int maxWidth = SLOT_SIZE - 6;
+        String clipped = label;
+        while (!clipped.isEmpty() && graphics.getFontMetrics().stringWidth(clipped) > maxWidth) {
+            clipped = clipped.substring(0, clipped.length() - 1);
+        }
+        int textWidth = graphics.getFontMetrics().stringWidth(clipped);
+        int textX = centerX + (SLOT_SIZE - textWidth) / 2;
+        graphics.setColor(new Color(220, 225, 235, 220));
+        graphics.drawString(clipped, textX, baselineY);
+    }
+
+    private void drawBarIndicator(Graphics2D graphics, int x, int y, int activeIndex, int totalBars) {
+        String text = "Bar " + activeIndex + "/" + totalBars;
+        graphics.setColor(new Color(180, 188, 200, 200));
+        graphics.drawString(text, x, y);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsPlugin.java
@@ -1,0 +1,151 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+import java.awt.event.KeyEvent;
+import java.util.List;
+
+@PluginDescriptor(
+        name = PluginConstants.DEFAULT_PREFIX + "Action Bars",
+        description = "Displays an RS3-style action bar overlay.",
+        authors = { "Microbot" },
+        version = ActionbarsPlugin.version,
+        minClientVersion = "1.9.9.1",
+        tags = { "overlay", "ui", "action bar" },
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+public class ActionbarsPlugin extends Plugin implements KeyListener {
+    public static final String version = "1.1.0";
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private ActionbarsOverlay actionbarsOverlay;
+
+    @Inject
+    private ActionbarsConfig config;
+
+    @Inject
+    private KeyManager keyManager;
+
+    @Provides
+    ActionbarsConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(ActionbarsConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(actionbarsOverlay);
+        }
+        keyManager.registerKeyListener(this);
+    }
+
+    @Override
+    protected void shutDown() {
+        keyManager.unregisterKeyListener(this);
+        if (overlayManager != null) {
+            overlayManager.remove(actionbarsOverlay);
+        }
+    }
+
+    @Override
+    public void keyTyped(KeyEvent e) {
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (config.nextBarHotkey().matches(e)) {
+            e.consume();
+            shiftActiveBar(1);
+            return;
+        }
+
+        if (config.previousBarHotkey().matches(e)) {
+            e.consume();
+            shiftActiveBar(-1);
+            return;
+        }
+
+        if (!Microbot.isLoggedIn()) {
+            return;
+        }
+
+        Integer slotIndex = getSlotIndex(e);
+        if (slotIndex == null) {
+            return;
+        }
+
+        ActionbarsBar activeBar = ActionbarsDefinitions.resolveActiveBar(
+                config.actionBars(),
+                config.activeBarIndex()
+        );
+        ActionbarsSlot slot = activeBar.getSlot(slotIndex);
+        if (slot == null || slot.getAction().getType() == ActionbarsActionType.NONE) {
+            return;
+        }
+
+        e.consume();
+        slot.getAction().execute();
+    }
+
+    @Override
+    public void keyReleased(KeyEvent e) {
+    }
+
+    private void shiftActiveBar(int delta) {
+        List<ActionbarsBar> bars = ActionbarsDefinitions.parseBars(config.actionBars());
+        int currentIndex = ActionbarsDefinitions.clampActiveIndex(bars, config.activeBarIndex());
+        int totalBars = bars.size();
+        int nextIndex = currentIndex + delta;
+        if (nextIndex < 1) {
+            nextIndex = totalBars;
+        } else if (nextIndex > totalBars) {
+            nextIndex = 1;
+        }
+        ActionbarsDefinitions.updateActiveBarIndex(nextIndex);
+    }
+
+    private Integer getSlotIndex(KeyEvent e) {
+        switch (e.getKeyCode()) {
+            case KeyEvent.VK_1:
+                return 0;
+            case KeyEvent.VK_2:
+                return 1;
+            case KeyEvent.VK_3:
+                return 2;
+            case KeyEvent.VK_4:
+                return 3;
+            case KeyEvent.VK_5:
+                return 4;
+            case KeyEvent.VK_6:
+                return 5;
+            case KeyEvent.VK_7:
+                return 6;
+            case KeyEvent.VK_8:
+                return 7;
+            case KeyEvent.VK_9:
+                return 8;
+            case KeyEvent.VK_0:
+                return 9;
+            case KeyEvent.VK_MINUS:
+                return 10;
+            case KeyEvent.VK_EQUALS:
+                return 11;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsSlot.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/actionbars/ActionbarsSlot.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.microbot.actionbars;
+
+public class ActionbarsSlot {
+    private final String label;
+    private final ActionbarsAction action;
+
+    public ActionbarsSlot(String label, ActionbarsAction action) {
+        this.label = label == null ? "" : label.trim();
+        this.action = action == null ? new ActionbarsAction(ActionbarsActionType.NONE, "") : action;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public ActionbarsAction getAction() {
+        return action;
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow users to configure what each action bar button does instead of hardcoded behavior. 
- Make the overlay movable (draggable) so users can place it where they want. 
- Support an arbitrary number of action bars and ensure only the configured active bar responds to key presses.

### Description
- Added a new configuration and parsing layer with `ActionbarsConfig`, `ActionbarsDefinitions`, `ActionbarsBar`, and `ActionbarsSlot` to parse multi-line, 12-slot-per-line bar definitions stored in the `actionBars` config string. 
- Implemented `ActionbarsAction` and `ActionbarsActionType` to represent and execute slot actions (examples: `EAT_FOOD`, `EAT_FAST_FOOD`, `DRINK_PRAYER_POTION`, `TOGGLE_SPEC`, `TOGGLE_PRAYER`). 
- Updated the plugin to register a `KeyListener` and handle hotkeys: `nextBarHotkey` / `previousBarHotkey` to cycle bars and numeric keys (`1`–`0`, `-`, `=`) to trigger slots on the active bar; active index is persisted via `activeBarIndex`. 
- Made the overlay draggable by calling `setMovable(true)` and enhanced rendering in `ActionbarsOverlay` to show per-slot labels (or fallback labels) and an active-bar indicator.

### Testing
- No automated tests were executed (`./gradlew test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698650a99c9c833088d44677477c3afc)