### PR TITLE
fix(f2p-fishing): refresh cached fishing action for lure spots; bump to 1.1.3

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingConfig.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+@ConfigGroup("f2pfishing")
+public interface F2pFishingConfig extends Config {
+    @ConfigSection(
+            name = "General",
+            description = "General settings",
+            position = 0
+    )
+    String generalSection = "general";
+
+    @ConfigItem(
+            keyName = "fish",
+            name = "Fish",
+            description = "Select which F2P fish to catch",
+            position = 0,
+            section = generalSection
+    )
+    default F2pFishingFish fish() {
+        return F2pFishingFish.SHRIMP_AND_ANCHOVIES;
+    }
+
+    @ConfigItem(
+            keyName = "mode",
+            name = "Mode",
+            description = "Choose whether to bank or drop fish",
+            position = 1,
+            section = generalSection
+    )
+    default F2pFishingMode mode() {
+        return F2pFishingMode.FISH_DROP;
+    }
+
+    @ConfigItem(
+            keyName = "enableAntiban",
+            name = "Enable Antiban",
+            description = "Use fishing antiban settings",
+            position = 3,
+            section = generalSection
+    )
+    default boolean enableAntiban() {
+        return true;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingFish.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingFish.java
@@ -1,0 +1,57 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+import lombok.Getter;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.autofishing.enums.Fish;
+import net.runelite.client.plugins.microbot.autofishing.enums.FishingMethod;
+
+import java.util.List;
+
+@Getter
+public enum F2pFishingFish {
+    SHRIMP_AND_ANCHOVIES("Shrimp + Anchovies", Fish.SHRIMP_AND_ANCHOVIES),
+    SARDINE("Sardine", Fish.SARDINE),
+    HERRING("Herring", Fish.HERRING),
+    TROUT_AND_SALMON("Trout + Salmon", Fish.TROUT_AND_SALMON),
+    PIKE("Pike", Fish.PIKE),
+    LOBSTER("Lobster", Fish.LOBSTER),
+    TUNA_AND_SWORDFISH("Tuna + Swordfish", Fish.TUNA_AND_SWORDFISH);
+
+    private final String displayName;
+    private final Fish fish;
+
+    F2pFishingFish(String displayName, Fish fish) {
+        this.displayName = displayName;
+        this.fish = fish;
+    }
+
+    public List<String> getItemNames() {
+        return fish.getItemNames();
+    }
+
+    public List<String> getActions() {
+        return fish.getActions();
+    }
+
+    public List<String> getRequiredItems() {
+        return fish.getRequiredItems();
+    }
+
+    public int[] getFishingSpotIds() {
+        return fish.getFishingSpot();
+    }
+
+    public WorldPoint getClosestLocation(WorldPoint playerLocation) {
+        return fish.getClosestLocation(playerLocation);
+    }
+
+    public int getLevelRequired() {
+        FishingMethod method = fish.getMethod();
+        return method != null ? method.getLevelRequired() : 1;
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingMode.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingMode.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+public enum F2pFishingMode {
+    FISH_DROP("Fish + Drop"),
+    FISH_BANK("Fish + Bank");
+
+    private final String label;
+
+    F2pFishingMode(String label) {
+        this.label = label;
+    }
+
+    public boolean isBankingMode() {
+        return this == F2pFishingMode.FISH_BANK;
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingOverlay.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.LineComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.time.Duration;
+
+public class F2pFishingOverlay extends OverlayPanel {
+    @Inject
+    F2pFishingOverlay(F2pFishingPlugin plugin) {
+        panelComponent.setPreferredSize(new java.awt.Dimension(220, 0));
+    }
+
+    @Override
+    public java.awt.Dimension render(java.awt.Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("F2P Fishing")
+                .leftColor(Color.CYAN)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status")
+                .right(F2pFishingScript.status)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Mode")
+                .right(F2pFishingScript.modeLabel)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Runtime")
+                .right(formatDuration(F2pFishingScript.getRuntime()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Fish caught")
+                .right(Integer.toString(F2pFishingScript.fishCaught))
+                .build());
+        return super.render(graphics);
+    }
+
+    private String formatDuration(Duration duration) {
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingPlugin.java
@@ -1,0 +1,55 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginConstants.DEFAULT_PREFIX + "F2P Fishing",
+        description = "F2P fishing with banking, dropping, and GE restocking",
+        tags = {"fishing", "f2p", "microbot"},
+        version = F2pFishingPlugin.version,
+        minClientVersion = "2.0.13",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class F2pFishingPlugin extends Plugin {
+    public static final String version = "1.1.3";
+
+    @Inject
+    private F2pFishingConfig config;
+
+    @Provides
+    F2pFishingConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(F2pFishingConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private F2pFishingOverlay overlay;
+
+    @Inject
+    private F2pFishingScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        overlayManager.add(overlay);
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pfishing/F2pFishingScript.java
@@ -1,0 +1,399 @@
+package net.runelite.client.plugins.microbot.f2pfishing;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class F2pFishingScript extends Script {
+    private static final List<String> CONSUMABLE_ITEMS = List.of("Fishing bait", "Feather");
+
+    public static String status = "Idle";
+    public static String modeLabel = "";
+    public static int fishCaught = 0;
+
+    private static long startTimeMs;
+    private int lastInventoryCount;
+    private F2pFishingFish selectedFish;
+    private WorldPoint fishingLocation;
+    private String fishAction = "";
+    private boolean useAntiban;
+
+    public boolean run(F2pFishingConfig config) {
+        startTimeMs = System.currentTimeMillis();
+        fishCaught = 0;
+        lastInventoryCount = 0;
+        status = "Starting";
+        modeLabel = config.mode().toString();
+        selectedFish = config.fish();
+        useAntiban = config.enableAntiban();
+
+        Rs2Antiban.resetAntibanSettings();
+        if (useAntiban) {
+            Rs2Antiban.antibanSetupTemplates.applyFishingSetup();
+            Rs2AntibanSettings.actionCooldownChance = 0.2;
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run() || !Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (useAntiban && Rs2AntibanSettings.actionCooldownActive) {
+                    return;
+                }
+
+                if (selectedFish != config.fish()) {
+                    selectedFish = config.fish();
+                    fishAction = "";
+                    fishingLocation = null;
+                    lastInventoryCount = 0;
+                }
+                modeLabel = config.mode().toString();
+                updateFishCount();
+
+                if (!hasRequiredLevel()) {
+                    status = "Fishing level too low";
+                    return;
+                }
+
+                if (Rs2Inventory.isFull()) {
+                    if (config.mode().isBankingMode()) {
+                        status = "Banking";
+                        bankFish();
+                    } else {
+                        status = "Dropping";
+                        dropFish();
+                    }
+                    return;
+                }
+
+                if (!hasRequiredSupplies(config)) {
+                    status = "Getting supplies";
+                    handleGettingSupplies(config);
+                    return;
+                }
+
+                if (isBusyFishing() || Rs2Player.isMoving()) {
+                    return;
+                }
+
+                if (!isAtFishingLocation()) {
+                    status = "Walking to spot";
+                    handleTraveling();
+                    return;
+                }
+
+                status = "Fishing " + selectedFish;
+                handleFishing();
+            } catch (Exception ex) {
+                log.error("F2P Fishing error", ex);
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        status = "Stopped";
+        Rs2Antiban.resetAntibanSettings();
+    }
+
+    public static Duration getRuntime() {
+        if (startTimeMs == 0) {
+            return Duration.ZERO;
+        }
+        long elapsed = System.currentTimeMillis() - startTimeMs;
+        return Duration.ofMillis(elapsed);
+    }
+
+    private void handleTraveling() {
+        if (fishingLocation == null) {
+            fishingLocation = selectedFish.getClosestLocation(Rs2Player.getWorldLocation());
+        }
+        if (fishingLocation != null) {
+            Rs2Walker.walkTo(fishingLocation);
+        }
+    }
+
+    private void handleFishing() {
+        Rs2NpcModel fishingSpot = findNearestFishingSpot();
+        if (fishingSpot == null) {
+            sleep(1000, 2000);
+            return;
+        }
+        if (fishAction.isEmpty() || !hasFishingAction(fishingSpot, fishAction)) {
+            fishAction = selectPreferredAction(fishingSpot, selectedFish.getActions());
+        }
+        if (!fishAction.isEmpty() && Rs2Npc.interact(fishingSpot, fishAction)) {
+            sleepUntil(() -> Rs2Player.isInteracting() || Rs2Player.isAnimating(), 2000);
+            Rs2Player.waitForXpDrop(Skill.FISHING);
+            if (useAntiban) {
+                Rs2Antiban.actionCooldown();
+                Rs2Antiban.takeMicroBreakByChance();
+            }
+        }
+    }
+
+    private void bankFish() {
+        if (!Rs2Bank.walkToBankAndUseBank()) {
+            return;
+        }
+        Rs2Bank.depositAllExcept(getItemsToKeep().toArray(new String[0]));
+        sleepUntil(() -> !Rs2Inventory.isFull(), 2000);
+        Rs2Bank.closeBank();
+    }
+
+    private void dropFish() {
+        Rs2Inventory.dropAll(selectedFish.getItemNames().toArray(new String[0]));
+    }
+
+    private void handleGettingSupplies(F2pFishingConfig config) {
+        if (!Rs2Bank.walkToBankAndUseBank()) {
+            status = "Bank unavailable";
+            return;
+        }
+
+        Rs2Bank.depositAll();
+
+        Map<String, Integer> missingItems = getMissingItemsFromBank(config);
+        if (!missingItems.isEmpty()) {
+            Rs2Bank.closeBank();
+            buyMissingItems(missingItems);
+            return;
+        }
+
+        withdrawRequiredItems(config);
+        if (!hasRequiredSupplies(config)) {
+            status = "Waiting for supplies";
+            return;
+        }
+        Rs2Bank.closeBank();
+    }
+
+    private void buyMissingItems(Map<String, Integer> missingItems) {
+        if (missingItems.isEmpty()) {
+            return;
+        }
+
+        int totalCost = estimatePurchaseCost(missingItems);
+        ensureCoins(totalCost);
+
+        if (!Rs2GrandExchange.walkToGrandExchange()) {
+            status = "Could not reach GE";
+            return;
+        }
+        if (!Rs2GrandExchange.openExchange()) {
+            status = "GE unavailable";
+            return;
+        }
+
+        if (Rs2GrandExchange.getAvailableSlotsCount() == 0) {
+            if (Rs2GrandExchange.hasSoldOffer() || Rs2GrandExchange.hasBoughtOffer()) {
+                Rs2GrandExchange.collectAllToBank();
+            } else {
+                Rs2GrandExchange.abortAllOffers(true);
+            }
+        }
+
+        for (Map.Entry<String, Integer> entry : missingItems.entrySet()) {
+            int gePrice = Microbot.getRs2ItemManager().getGEPrice(entry.getKey());
+            int maxPrice = Math.max(1, (int) (gePrice * 1.1));
+            Rs2GrandExchange.buyItem(entry.getKey(), maxPrice, entry.getValue());
+            sleep(1200, 1800);
+        }
+
+        status = "Waiting for GE buys";
+        sleepUntil(Rs2GrandExchange::hasFinishedBuyingOffers, 120000);
+        Rs2GrandExchange.collectAllToBank();
+        Rs2GrandExchange.closeExchange();
+    }
+
+    private void ensureCoins(int totalCost) {
+        if (totalCost <= 0) {
+            return;
+        }
+        int currentCoins = Rs2Inventory.itemQuantity(ItemID.COINS_995);
+        if (currentCoins >= totalCost) {
+            return;
+        }
+        if (Rs2Bank.walkToBankAndUseBank()) {
+            int withdrawAmount = totalCost - currentCoins;
+            Rs2Bank.withdrawX(true, ItemID.COINS_995, withdrawAmount);
+            sleepUntil(() -> Rs2Inventory.itemQuantity(ItemID.COINS_995) >= totalCost, 2000);
+            Rs2Bank.closeBank();
+        }
+    }
+
+    private int estimatePurchaseCost(Map<String, Integer> missingItems) {
+        int totalCost = 0;
+        for (Map.Entry<String, Integer> entry : missingItems.entrySet()) {
+            int price = Microbot.getRs2ItemManager().getGEPrice(entry.getKey());
+            int quantity = Math.max(1, entry.getValue());
+            totalCost += (int) (price * quantity * 1.1);
+        }
+        return totalCost;
+    }
+
+    private void withdrawRequiredItems(F2pFishingConfig config) {
+        for (String item : selectedFish.getRequiredItems()) {
+            if (isConsumable(item)) {
+                int currentAmount = Rs2Inventory.itemQuantity(item);
+                if (currentAmount == 0 && Rs2Bank.hasItem(item)) {
+                    Rs2Bank.withdrawAll(item);
+                    sleepUntil(() -> Rs2Inventory.itemQuantity(item) > 0 || !Rs2Bank.hasItem(item), 2000);
+                }
+                continue;
+            }
+            if (requiresInventory(item)) {
+                if (Rs2Inventory.hasItem(item)) {
+                    continue;
+                }
+            } else if (hasItemEquippedOrInventory(item)) {
+                continue;
+            }
+            Rs2Bank.withdrawOne(item);
+            sleepUntil(() -> Rs2Inventory.hasItem(item), 2000);
+        }
+    }
+
+    private Map<String, Integer> getMissingItemsFromBank(F2pFishingConfig config) {
+        Map<String, Integer> missingItems = new LinkedHashMap<>();
+        for (String item : selectedFish.getRequiredItems()) {
+            int currentAmount = Rs2Inventory.itemQuantity(item);
+            if (isConsumable(item)) {
+                boolean hasAny = currentAmount > 0 || Rs2Bank.hasItem(item);
+                if (!hasAny) {
+                    missingItems.put(item, 1);
+                }
+                continue;
+            }
+            if (hasItemEquippedOrInventory(item)) {
+                continue;
+            }
+            if (!Rs2Bank.hasItem(item)) {
+                missingItems.put(item, 1);
+            }
+        }
+        return missingItems;
+    }
+
+    private boolean isConsumable(String itemName) {
+        return CONSUMABLE_ITEMS.contains(itemName);
+    }
+
+    private boolean hasRequiredSupplies(F2pFishingConfig config) {
+        for (String item : selectedFish.getRequiredItems()) {
+            if (isConsumable(item)) {
+                if (Rs2Inventory.itemQuantity(item) == 0) {
+                    return false;
+                }
+                continue;
+            }
+            if (requiresInventory(item)) {
+                if (!Rs2Inventory.hasItem(item)) {
+                    return false;
+                }
+            } else if (!hasItemEquippedOrInventory(item)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasItemEquippedOrInventory(String item) {
+        return Rs2Inventory.hasItem(item) || Rs2Equipment.isWearing(item);
+    }
+
+    private boolean requiresInventory(String item) {
+        return "Fishing rod".equalsIgnoreCase(item);
+    }
+
+    private boolean isAtFishingLocation() {
+        if (fishingLocation == null) {
+            return false;
+        }
+        return Rs2Player.getWorldLocation().distanceTo(fishingLocation) <= 5;
+    }
+
+    private boolean hasFishingAction(Rs2NpcModel fishingSpot, String action) {
+        return !Rs2Npc.getAvailableAction(fishingSpot, List.of(action)).isEmpty();
+    }
+
+    private boolean isBusyFishing() {
+        if (Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
+            return true;
+        }
+        return Microbot.getClientThread().invoke(() -> {
+            if (Microbot.getClient().getLocalPlayer() == null) {
+                return false;
+            }
+            return Microbot.getClient().getLocalPlayer().isInteracting();
+        });
+    }
+
+    private String selectPreferredAction(Rs2NpcModel fishingSpot, List<String> actions) {
+        for (String action : actions) {
+            String available = Rs2Npc.getAvailableAction(fishingSpot, List.of(action));
+            if (!available.isEmpty()) {
+                return available;
+            }
+        }
+        return Rs2Npc.getAvailableAction(fishingSpot, actions);
+    }
+
+    private boolean hasRequiredLevel() {
+        int fishingLevel = Microbot.getClient().getRealSkillLevel(Skill.FISHING);
+        return fishingLevel >= selectedFish.getLevelRequired();
+    }
+
+    private Rs2NpcModel findNearestFishingSpot() {
+        int[] spotIds = selectedFish.getFishingSpotIds();
+        return Rs2Npc.getNpcs(npc -> Arrays.stream(spotIds).anyMatch(id -> npc.getId() == id))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void updateFishCount() {
+        int currentCount = countRelevantFish();
+        int delta = currentCount - lastInventoryCount;
+        if (delta > 0) {
+            fishCaught += delta;
+        }
+        lastInventoryCount = currentCount;
+    }
+
+    private int countRelevantFish() {
+        int count = 0;
+        for (String itemName : selectedFish.getItemNames()) {
+            count += Rs2Inventory.itemQuantity(itemName);
+        }
+        return count;
+    }
+
+    private List<String> getItemsToKeep() {
+        return selectedFish.getRequiredItems();
+    }
+}

--- a/src/main/resources/net/runelite/client/plugins/microbot/f2pfishing/docs/README.md
+++ b/src/main/resources/net/runelite/client/plugins/microbot/f2pfishing/docs/README.md
@@ -1,0 +1,18 @@
+# F2P Fishing
+
+Automates free-to-play fishing with support for banking or dropping fish and restocking gear via the Grand Exchange when needed.
+
+## Features
+- Select F2P fish types (shrimp/anchovies, sardine, herring, trout/salmon, pike, lobster, tuna/swordfish).
+- Bank or drop fish when inventory fills.
+- Automatically withdraw required tools and consumables.
+- If the bank is missing required items, the script walks to the Grand Exchange to purchase them.
+
+## Setup
+1. Configure the fish type and mode in the plugin settings.
+2. Make sure you have coins in the bank for restocking supplies.
+3. Start the plugin; the script will handle travel, fishing, and inventory management.
+
+## Limitations
+- Uses the nearest known fishing spots for the selected fish.
+- Requires sufficient Fishing level for the selected fish.


### PR DESCRIPTION
### Motivation
- Fix a bug where a cached fishing action (e.g., `bait`) was used against a different spot that requires a different action (e.g., `lure`), causing incorrect interactions while trout/salmon fishing. 
- Ensure the script uses the actual available action on the current `fishingSpot` instead of a stale cached value.

### Description
- Added `hasFishingAction(Rs2NpcModel, String)` to `F2pFishingScript` and updated `handleFishing()` to reselect the preferred action when `fishAction` is empty or not available on the current spot by calling `selectPreferredAction(...)` again. 
- The interaction flow still uses `sleepUntil(...)` and `Rs2Player.waitForXpDrop(Skill.FISHING)` and preserves the antiban hooks, with only the action revalidation behavior changed. 
- Bumped the plugin version in `F2pFishingPlugin` from `1.1.2` to `1.1.3` to reflect the fix.

### Testing
- No automated tests were executed (`./gradlew test` was not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69867564b0a08330a58c82c973b9bda3)