### PR TITLE
fix(f2pcooker): stop walking once inside stove area; bump version to 1.0.5

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerConfig.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.f2pcooker;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+
+@ConfigGroup("f2pcooker")
+public interface F2pCookerConfig extends Config {
+    @ConfigSection(
+            name = "Cooking",
+            description = "F2P cooker settings",
+            position = 0
+    )
+    String cookingSection = "cooking";
+
+    @ConfigItem(
+            keyName = "useBestFoodForLevel",
+            name = "Use best food for level",
+            description = "Automatically picks the highest F2P food your Cooking level can cook and that exists in bank",
+            position = 0,
+            section = cookingSection
+    )
+    default boolean useBestFoodForLevel() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "fallbackFood",
+            name = "Fallback food",
+            description = "Food used when auto mode is disabled",
+            position = 1,
+            section = cookingSection
+    )
+    default F2pCookerFood fallbackFood() {
+        return F2pCookerFood.SHRIMP;
+    }
+
+    @ConfigItem(
+            keyName = "enableAntiban",
+            name = "Enable Antiban",
+            description = "Use cooking antiban settings",
+            position = 2,
+            section = cookingSection
+    )
+    default boolean enableAntiban() {
+        return true;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerFood.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerFood.java
@@ -1,0 +1,41 @@
+package net.runelite.client.plugins.microbot.f2pcooker;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum F2pCookerFood {
+    SHRIMP("Shrimp", 317, 1),
+    ANCHOVIES("Anchovies", 321, 1),
+    SARDINE("Sardine", 327, 1),
+    HERRING("Herring", 345, 5),
+    TROUT("Trout", 335, 15),
+    PIKE("Pike", 349, 20),
+    SALMON("Salmon", 331, 25),
+    TUNA("Tuna", 359, 30),
+    LOBSTER("Lobster", 377, 40),
+    SWORDFISH("Swordfish", 371, 45);
+
+    private final String name;
+    private final int rawItemId;
+    private final int requiredLevel;
+
+    private static final List<F2pCookerFood> LEVEL_ORDERED = Arrays.stream(values())
+            .sorted(Comparator.comparingInt(F2pCookerFood::getRequiredLevel))
+            .collect(Collectors.toList());
+
+    public static List<F2pCookerFood> getLevelOrdered() {
+        return LEVEL_ORDERED;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s (lvl %d)", name, requiredLevel);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerOverlay.java
@@ -1,0 +1,47 @@
+package net.runelite.client.plugins.microbot.f2pcooker;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.time.Duration;
+
+public class F2pCookerOverlay extends OverlayPanel {
+    @Inject
+    F2pCookerOverlay(F2pCookerPlugin plugin) {
+        super(plugin);
+        panelComponent.setPreferredSize(new java.awt.Dimension(220, 0));
+    }
+
+    @Override
+    public java.awt.Dimension render(java.awt.Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("KSP F2P Cooker")
+                .color(Color.CYAN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time Status:")
+                .right(F2pCookerScript.status)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time Running:")
+                .right(formatDuration(F2pCookerScript.getRuntime()))
+                .build());
+
+        return super.render(graphics);
+    }
+
+    private String formatDuration(Duration duration) {
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerPlugin.java
@@ -1,0 +1,55 @@
+package net.runelite.client.plugins.microbot.f2pcooker;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginConstants.DEFAULT_PREFIX + "F2P Cooker",
+        description = "Cooks F2P fish at the Edgeville stove (3078, 3493, 0) using OSRS wiki level progression",
+        tags = {"cooking", "f2p", "edgeville", "microbot"},
+        version = F2pCookerPlugin.version,
+        minClientVersion = "2.0.13",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class F2pCookerPlugin extends Plugin {
+    public static final String version = "1.0.5";
+
+    @Inject
+    private F2pCookerConfig config;
+
+    @Inject
+    private F2pCookerScript script;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private F2pCookerOverlay overlay;
+
+    @Provides
+    F2pCookerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(F2pCookerConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        overlayManager.add(overlay);
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/f2pcooker/F2pCookerScript.java
@@ -1,0 +1,221 @@
+package net.runelite.client.plugins.microbot.f2pcooker;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.GameObject;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.keyboard.Rs2Keyboard;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+import net.runelite.client.plugins.microbot.util.widget.Rs2Widget;
+
+import java.awt.event.KeyEvent;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class F2pCookerScript extends Script {
+    private static final WorldPoint EDGEVILLE_STOVE_POINT = new WorldPoint(3078, 3493, 0);
+    private static final int EDGEVILLE_STOVE_ID = 12269;
+    private static final int STOVE_AREA_MAX_X = 3081;
+    private static final int STOVE_AREA_MAX_Y = 3496;
+    private static final int STOVE_AREA_MIN_X = 3077;
+    private static final int STOVE_AREA_MIN_Y = 3489;
+    private static final String COOK_WIDGET_TEXT = "How many would you like to cook?";
+
+    public static String status = "Idle";
+
+    private static long startTimeMs;
+    private F2pCookerFood selectedFood;
+    private boolean useAntiban;
+
+    public boolean run(F2pCookerConfig config) {
+        status = "Starting";
+        startTimeMs = System.currentTimeMillis();
+        selectedFood = null;
+        useAntiban = config.enableAntiban();
+
+        Rs2Antiban.resetAntibanSettings();
+        if (useAntiban) {
+            Rs2Antiban.antibanSetupTemplates.applyCookingSetup();
+            Rs2AntibanSettings.dynamicActivity = true;
+            Rs2AntibanSettings.dynamicIntensity = true;
+            Rs2AntibanSettings.actionCooldownChance = 0.1;
+            Rs2AntibanSettings.microBreakChance = 0.01;
+            Rs2AntibanSettings.microBreakDurationLow = 0;
+            Rs2AntibanSettings.microBreakDurationHigh = 3;
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run() || !Microbot.isLoggedIn()) {
+                    return;
+                }
+
+                if (useAntiban && Rs2AntibanSettings.actionCooldownActive) {
+                    return;
+                }
+
+                if (Rs2Player.isMoving()) {
+                    return;
+                }
+
+                if (Rs2Widget.findWidget(COOK_WIDGET_TEXT, null, false) != null) {
+                    status = "Confirming cook-all";
+                    Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+                    sleep(300, 700);
+                    return;
+                }
+
+                if (Rs2Inventory.isFull() && !hasAnyRawFood()) {
+                    status = "Banking";
+                    bankForRawFood(config);
+                    return;
+                }
+
+                if (!hasAnyRawFood()) {
+                    status = "Getting raw food";
+                    bankForRawFood(config);
+                    return;
+                }
+
+                if (!isNearStove()) {
+                    status = "Walking to stove area";
+                    Rs2Walker.walkTo(EDGEVILLE_STOVE_POINT, 1);
+                    return;
+                }
+
+                if (Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
+                    return;
+                }
+
+                status = "Cooking " + getCurrentFood().getName();
+                cookInventory();
+            } catch (Exception ex) {
+                log.error("F2P Cooker error", ex);
+            }
+        }, 0, 700, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        status = "Stopped";
+        Rs2Antiban.resetAntibanSettings();
+    }
+
+    public static Duration getRuntime() {
+        if (startTimeMs == 0) {
+            return Duration.ZERO;
+        }
+        long elapsed = System.currentTimeMillis() - startTimeMs;
+        return Duration.ofMillis(elapsed);
+    }
+
+    private void bankForRawFood(F2pCookerConfig config) {
+        if (!Rs2Bank.walkToBankAndUseBank()) {
+            status = "Bank unavailable";
+            return;
+        }
+
+        Rs2Bank.depositAll();
+
+        F2pCookerFood foodToWithdraw = determineFoodToCook(config);
+        if (foodToWithdraw == null) {
+            status = "No F2P raw fish in bank";
+            Microbot.showMessage("F2P Cooker: no suitable raw fish found in bank for your selected mode.");
+            shutdown();
+            return;
+        }
+
+        selectedFood = foodToWithdraw;
+        Rs2Bank.withdrawAll(selectedFood.getRawItemId());
+        sleepUntil(() -> Rs2Inventory.hasItem(selectedFood.getRawItemId()), 2500);
+        Rs2Bank.closeBank();
+    }
+
+    private void cookInventory() {
+        GameObject stove = findEdgevilleStove();
+
+        if (stove == null) {
+            status = "Stove not found in area";
+            return;
+        }
+
+        status = "Using stove (Cook)";
+        if (Rs2GameObject.interact(stove, "Cook")) {
+            sleepUntil(() -> Rs2Widget.findWidget(COOK_WIDGET_TEXT, null, false) != null || Rs2Player.isAnimating(), 3000);
+            if (Rs2Widget.findWidget(COOK_WIDGET_TEXT, null, false) != null) {
+                Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
+            }
+            Rs2Player.waitForXpDrop(Skill.COOKING, 4000);
+            if (useAntiban) {
+                Rs2Antiban.actionCooldown();
+                Rs2Antiban.takeMicroBreakByChance();
+            }
+        }
+    }
+
+    private GameObject findEdgevilleStove() {
+        Optional<GameObject> stove = Rs2GameObject.getGameObjects().stream()
+                .filter(gameObject -> gameObject != null && gameObject.getId() == EDGEVILLE_STOVE_ID)
+                .filter(gameObject -> isInStoveSearchArea(gameObject.getWorldLocation()))
+                .min(Comparator.comparingInt(gameObject -> Rs2Player.distanceTo(gameObject.getWorldLocation())));
+        return stove.orElse(null);
+    }
+
+    private boolean isInStoveSearchArea(WorldPoint worldPoint) {
+        if (worldPoint == null) {
+            return false;
+        }
+        return worldPoint.getX() >= STOVE_AREA_MIN_X
+                && worldPoint.getX() <= STOVE_AREA_MAX_X
+                && worldPoint.getY() >= STOVE_AREA_MIN_Y
+                && worldPoint.getY() <= STOVE_AREA_MAX_Y
+                && worldPoint.getPlane() == EDGEVILLE_STOVE_POINT.getPlane();
+    }
+
+    private boolean isNearStove() {
+        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        return isInStoveSearchArea(playerLocation);
+    }
+
+    private F2pCookerFood getCurrentFood() {
+        if (selectedFood != null && Rs2Inventory.hasItem(selectedFood.getRawItemId())) {
+            return selectedFood;
+        }
+
+        return F2pCookerFood.getLevelOrdered().stream()
+                .filter(food -> Rs2Inventory.hasItem(food.getRawItemId()))
+                .max(Comparator.comparingInt(F2pCookerFood::getRequiredLevel))
+                .orElse(F2pCookerFood.SHRIMP);
+    }
+
+    private boolean hasAnyRawFood() {
+        return F2pCookerFood.getLevelOrdered().stream().anyMatch(food -> Rs2Inventory.hasItem(food.getRawItemId()));
+    }
+
+    private F2pCookerFood determineFoodToCook(F2pCookerConfig config) {
+        if (!config.useBestFoodForLevel()) {
+            return Rs2Bank.hasItem(config.fallbackFood().getRawItemId()) ? config.fallbackFood() : null;
+        }
+
+        int cookingLevel = Microbot.getClientThread().invoke(() -> Microbot.getClient().getRealSkillLevel(Skill.COOKING));
+        return F2pCookerFood.getLevelOrdered().stream()
+                .filter(food -> cookingLevel >= food.getRequiredLevel())
+                .filter(food -> Rs2Bank.hasItem(food.getRawItemId()))
+                .max(Comparator.comparingInt(F2pCookerFood::getRequiredLevel))
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a self-contained F2P cooker plugin that automates banking, cooking, and optional antiban behavior while showing runtime/status in an overlay.
- Centralize food data and selection logic with an enum so food choice is consistent and level-aware.
- Fix movement gating so the script stops walking as soon as the player is inside the configured stove area instead of requiring proximity to a single point.

### Description
- Added `F2pCookerConfig` with `enableAntiban()`, `useBestFoodForLevel()` and `fallbackFood()` configuration items.
- Added `F2pCookerFood` enum with item ids, required levels and `getLevelOrdered()` to drive selection logic.
- Added `F2pCookerOverlay` to display `status` and runtime using `F2pCookerScript.getRuntime()`.
- Added `F2pCookerPlugin` to wire config, script and overlay together and bumped `version` to `1.0.5`.
- Implemented `F2pCookerScript` with bank/walk/cook flow, antiban integration (`Rs2Antiban.*`), area-based stove lookup (`isInStoveSearchArea(...)`), and updated walking logic so `isNearStove()` checks the player location against the stove area; also updated status text to `"Walking to stove area"`.

### Testing
- Ran source verification via ripgrep for key changes with `rg` to confirm updated references, which succeeded.
- Attempted to run `./gradlew build -PpluginList=F2pCookerPlugin` but the Gradle wrapper download failed due to an environment proxy returning `HTTP/1.1 403 Forbidden`, so a full build could not be completed in this environment.
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c6462a52883309099ebcb2ea13f6b)