### PR TITLE
feat: add F2P cooker stage to KSP Account Builder

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderConfig.java
@@ -1,0 +1,94 @@
+package net.runelite.client.plugins.microbot.KSPAccountBuilder;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
+import net.runelite.client.config.Range;
+
+@ConfigGroup("KSPAccountBuilder")
+public interface KSPAccountBuilderConfig extends Config {
+    @ConfigSection(
+            name = "Targets",
+            description = "Level targets for the account builder",
+            position = 0
+    )
+    String targetsSection = "targets";
+
+    @ConfigSection(
+            name = "Flow",
+            description = "Order and completion behavior",
+            position = 1
+    )
+    String flowSection = "flow";
+
+    @ConfigItem(
+            keyName = "startSkill",
+            name = "Start skill",
+            description = "Which skill to train first",
+            position = 0,
+            section = flowSection
+    )
+    default KSPAccountBuilderStartSkill startSkill() {
+        return KSPAccountBuilderStartSkill.MINING;
+    }
+
+    @Range(min = 1, max = 99)
+    @ConfigItem(
+            keyName = "targetMiningLevel",
+            name = "Target mining level",
+            description = "Stop mining once this level is reached",
+            position = 1,
+            section = targetsSection
+    )
+    default int targetMiningLevel() {
+        return 30;
+    }
+
+    @Range(min = 1, max = 99)
+    @ConfigItem(
+            keyName = "targetWoodcuttingLevel",
+            name = "Target woodcutting level",
+            description = "Stop woodcutting once this level is reached",
+            position = 2,
+            section = targetsSection
+    )
+    default int targetWoodcuttingLevel() {
+        return 30;
+    }
+
+    @ConfigItem(
+            keyName = "stopWhenComplete",
+            name = "Stop when targets met",
+            description = "Disable the builder after both targets are met",
+            position = 1,
+            section = flowSection
+    )
+    default boolean stopWhenComplete() {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "minSwitchMinutes",
+            name = "Min switch minutes",
+            description = "Minimum minutes before switching tasks",
+            position = 2,
+            section = flowSection
+    )
+    @Range(min = 1, max = 240)
+    default int minSwitchMinutes() {
+        return 30;
+    }
+
+    @ConfigItem(
+            keyName = "maxSwitchMinutes",
+            name = "Max switch minutes",
+            description = "Maximum minutes before switching tasks",
+            position = 3,
+            section = flowSection
+    )
+    @Range(min = 1, max = 240)
+    default int maxSwitchMinutes() {
+        return 60;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderOverlay.java
@@ -1,0 +1,59 @@
+package net.runelite.client.plugins.microbot.KSPAccountBuilder;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.time.Duration;
+
+public class KSPAccountBuilderOverlay extends OverlayPanel {
+    @Inject
+    KSPAccountBuilderOverlay(KSPAccountBuilderPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_CENTER);
+    }
+
+    @Override
+    public Dimension render(java.awt.Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(240, 150));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("KSP Account Builder")
+                .color(Color.ORANGE)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Stage:")
+                .right(KSPAccountBuilderScript.stageLabel)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status:")
+                .right(KSPAccountBuilderScript.status)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time running:")
+                .right(formatDuration(KSPAccountBuilderScript.getRuntime()))
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Change Task in:")
+                .right(formatDuration(KSPAccountBuilderScript.getTimeUntilSwitch()))
+                .build());
+
+        return super.render(graphics);
+    }
+
+    private String formatDuration(Duration duration) {
+        long totalSeconds = duration.getSeconds();
+        long hours = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderPlugin.java
@@ -1,0 +1,91 @@
+package net.runelite.client.plugins.microbot.KSPAccountBuilder;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.plugins.microbot.KSPAutoMiner.KSPAutoMinerConfig;
+import net.runelite.client.plugins.microbot.KSPAutoWoodcutter.KSPAutoWoodcutterConfig;
+import net.runelite.client.plugins.microbot.autofishing.AutoFishingConfig;
+import net.runelite.client.plugins.microbot.gecooker.GECookerConfig;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginConstants.KSP + "Account Builder",
+        description = "Builds accounts by training Mining and Woodcutting",
+        tags = {"account", "mining", "woodcutting", "ksp"},
+        version = KSPAccountBuilderPlugin.version,
+        minClientVersion = "2.0.13",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KSPAccountBuilderPlugin extends Plugin {
+    public static final String version = "0.3.3";
+
+    @Inject
+    private KSPAccountBuilderConfig config;
+
+    @Inject
+    private KSPAutoMinerConfig minerConfig;
+
+    @Inject
+    private KSPAutoWoodcutterConfig woodcutterConfig;
+
+    @Inject
+    private AutoFishingConfig fishingConfig;
+
+    @Inject
+    private GECookerConfig cookerConfig;
+
+    @Provides
+    KSPAccountBuilderConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPAccountBuilderConfig.class);
+    }
+
+    @Provides
+    KSPAutoMinerConfig provideMinerConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPAutoMinerConfig.class);
+    }
+
+    @Provides
+    KSPAutoWoodcutterConfig provideWoodcutterConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPAutoWoodcutterConfig.class);
+    }
+
+    @Provides
+    AutoFishingConfig provideFishingConfig(ConfigManager configManager) {
+        return configManager.getConfig(AutoFishingConfig.class);
+    }
+
+    @Provides
+    GECookerConfig provideCookerConfig(ConfigManager configManager) {
+        return configManager.getConfig(GECookerConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private KSPAccountBuilderOverlay overlay;
+
+    @Inject
+    private KSPAccountBuilderScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        overlayManager.add(overlay);
+        script.run(config, minerConfig, woodcutterConfig, fishingConfig, cookerConfig);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderScript.java
@@ -1,0 +1,627 @@
+package net.runelite.client.plugins.microbot.KSPAccountBuilder;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.EquipmentInventorySlot;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.KSPAutoMiner.KSPAutoMinerConfig;
+import net.runelite.client.plugins.microbot.KSPAutoMiner.KSPAutoMinerRock;
+import net.runelite.client.plugins.microbot.KSPAutoMiner.KSPAutoMinerScript;
+import net.runelite.client.plugins.microbot.KSPAutoWoodcutter.KSPAutoWoodcutterConfig;
+import net.runelite.client.plugins.microbot.KSPAutoWoodcutter.KSPAutoWoodcutterScript;
+import net.runelite.client.plugins.microbot.KSPAutoWoodcutter.KSPAutoWoodcutterTree;
+import net.runelite.client.plugins.microbot.autofishing.AutoFishingConfig;
+import net.runelite.client.plugins.microbot.autofishing.AutoFishingScript;
+import net.runelite.client.plugins.microbot.autofishing.enums.Fish;
+import net.runelite.client.plugins.microbot.gecooker.GECookerConfig;
+import net.runelite.client.plugins.microbot.gecooker.GECookerScript;
+import net.runelite.client.plugins.microbot.gecooker.enums.CookingItem;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import net.runelite.api.coords.WorldPoint;
+
+@Slf4j
+public class KSPAccountBuilderScript extends Script {
+    public static String status = "Idle";
+    public static String stageLabel = "None";
+
+    private static long startTimeMs;
+    private static long stageStartTimeMs;
+    private static long stageDurationMs;
+    private final Random random = new Random();
+    private long nextToolCheckMs;
+    private static final long TOOL_CHECK_COOLDOWN_MS = 5000L;
+    private static final WorldPoint KARAMJA_CUSTOMS_DOCK = new WorldPoint(2953, 3146, 0);
+    private static final WorldPoint PORT_SARIM_DOCK = new WorldPoint(3027, 3217, 0);
+
+    private Stage currentStage = Stage.NONE;
+    private boolean minerRunning;
+    private boolean woodcutterRunning;
+    private boolean fishingRunning;
+    private boolean cookerRunning;
+
+    private static final List<ToolRequirement> PICKAXE_REQUIREMENTS = Arrays.asList(
+            new ToolRequirement(ItemID.BRONZE_PICKAXE, 1, 1, Skill.MINING),
+            new ToolRequirement(ItemID.IRON_PICKAXE, 1, 1, Skill.MINING),
+            new ToolRequirement(ItemID.STEEL_PICKAXE, 6, 5, Skill.MINING),
+            new ToolRequirement(ItemID.BLACK_PICKAXE, 11, 10, Skill.MINING),
+            new ToolRequirement(ItemID.MITHRIL_PICKAXE, 21, 20, Skill.MINING),
+            new ToolRequirement(ItemID.ADAMANT_PICKAXE, 31, 30, Skill.MINING),
+            new ToolRequirement(ItemID.RUNE_PICKAXE, 41, 40, Skill.MINING),
+            new ToolRequirement(ItemID.DRAGON_PICKAXE, 61, 60, Skill.MINING),
+            new ToolRequirement(ItemID.INFERNAL_PICKAXE, 61, 60, Skill.MINING),
+            new ToolRequirement(ItemID.CRYSTAL_PICKAXE, 71, 70, Skill.MINING)
+    );
+
+    private static final List<ToolRequirement> AXE_REQUIREMENTS = Arrays.asList(
+            new ToolRequirement(ItemID.BRONZE_AXE, 1, 1, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.IRON_AXE, 1, 1, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.STEEL_AXE, 6, 5, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.BLACK_AXE, 11, 10, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.MITHRIL_AXE, 21, 20, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.ADAMANT_AXE, 31, 30, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.RUNE_AXE, 41, 40, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.DRAGON_AXE, 61, 60, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.INFERNAL_AXE, 61, 60, Skill.WOODCUTTING),
+            new ToolRequirement(ItemID.CRYSTAL_AXE, 71, 70, Skill.WOODCUTTING)
+    );
+
+    @Inject
+    private KSPAutoMinerScript minerScript;
+
+    @Inject
+    private KSPAutoWoodcutterScript woodcutterScript;
+
+    @Inject
+    private AutoFishingScript fishingScript;
+
+    @Inject
+    private GECookerScript cookerScript;
+
+    @Inject
+    private ConfigManager configManager;
+
+    private enum Stage {
+        MINING,
+        WOODCUTTING,
+        F2P_FISHING,
+        F2P_COOKER,
+        NONE
+    }
+
+    public boolean run(KSPAccountBuilderConfig config,
+                       KSPAutoMinerConfig minerConfig,
+                       KSPAutoWoodcutterConfig woodcutterConfig,
+                       AutoFishingConfig fishingConfig,
+                       GECookerConfig cookerConfig) {
+        startTimeMs = System.currentTimeMillis();
+        status = "Starting";
+        KSPAccountBuilderStartSkill startSkill = config.startSkill();
+        if (startSkill == KSPAccountBuilderStartSkill.RANDOM) {
+            Stage[] startingStages = {Stage.MINING, Stage.WOODCUTTING, Stage.F2P_FISHING, Stage.F2P_COOKER};
+            currentStage = startingStages[random.nextInt(startingStages.length)];
+        } else {
+            if (startSkill == KSPAccountBuilderStartSkill.WOODCUTTING) {
+                currentStage = Stage.WOODCUTTING;
+            } else if (startSkill == KSPAccountBuilderStartSkill.F2P_FISHING) {
+                currentStage = Stage.F2P_FISHING;
+            } else if (startSkill == KSPAccountBuilderStartSkill.F2P_COOKER) {
+                currentStage = Stage.F2P_COOKER;
+            } else {
+                currentStage = Stage.MINING;
+            }
+        }
+        stageLabel = currentStage.name();
+        stageStartTimeMs = System.currentTimeMillis();
+        stageDurationMs = selectStageDurationMs(config);
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run()) {
+                    return;
+                }
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+                if (!minerRunning && !woodcutterRunning && !fishingRunning) {
+                    startStageIfNeeded(minerConfig, woodcutterConfig, fishingConfig);
+                }
+
+                boolean miningComplete = isMiningComplete(config);
+                boolean woodcuttingComplete = isWoodcuttingComplete(config);
+
+                if (miningComplete && woodcuttingComplete) {
+                    status = "Targets met";
+                    stageLabel = "Complete";
+                    stopAll();
+                    if (config.stopWhenComplete()) {
+                        shutdown();
+                    }
+                    return;
+                }
+
+                boolean shouldSwitchByTime = shouldSwitchByTime(config);
+
+                if ((currentStage == Stage.MINING && (miningComplete || shouldSwitchByTime))
+                        || (currentStage == Stage.WOODCUTTING && (woodcuttingComplete || shouldSwitchByTime))
+                        || (currentStage == Stage.F2P_FISHING && shouldSwitchByTime)
+                        || (currentStage == Stage.F2P_COOKER && shouldSwitchByTime)) {
+                    if (handleKaramjaExitBeforeSwitch()) {
+                        return;
+                    }
+                    stopCurrentStage();
+                    currentStage = getNextStage(currentStage);
+                    stageLabel = currentStage.name();
+                    stageStartTimeMs = System.currentTimeMillis();
+                    stageDurationMs = selectStageDurationMs(config);
+                }
+
+                if (currentStage == Stage.MINING && !miningComplete) {
+                    status = "Training Mining";
+                    startMiner(minerConfig);
+                } else if (currentStage == Stage.WOODCUTTING && !woodcuttingComplete) {
+                    status = "Training Woodcutting";
+                    startWoodcutter(woodcutterConfig);
+                } else if (currentStage == Stage.F2P_FISHING) {
+                    status = "Training F2P Fishing";
+                    startFishing(fishingConfig);
+                } else if (currentStage == Stage.F2P_COOKER) {
+                    status = "Training F2P Cooking";
+                    startCooker(cookerConfig);
+                }
+            } catch (Exception ex) {
+                Microbot.log("KSPAccountBuilder error: " + ex.getMessage());
+            }
+        }, 0, 800, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        stopAll();
+        super.shutdown();
+        status = "Stopped";
+    }
+
+    public static Duration getRuntime() {
+        if (startTimeMs == 0) {
+            return Duration.ZERO;
+        }
+        long elapsed = System.currentTimeMillis() - startTimeMs;
+        return Duration.ofMillis(elapsed);
+    }
+
+    public static Duration getTimeUntilSwitch() {
+        if (stageStartTimeMs == 0 || stageDurationMs <= 0) {
+            return Duration.ZERO;
+        }
+        long elapsed = System.currentTimeMillis() - stageStartTimeMs;
+        long remaining = stageDurationMs - elapsed;
+        if (remaining <= 0) {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis(remaining);
+    }
+
+    private boolean shouldSwitchByTime(KSPAccountBuilderConfig config) {
+        long elapsedMs = System.currentTimeMillis() - stageStartTimeMs;
+        return stageDurationMs > 0 && elapsedMs >= stageDurationMs;
+    }
+
+    private long selectStageDurationMs(KSPAccountBuilderConfig config) {
+        int minMinutes = config.minSwitchMinutes();
+        int maxMinutes = config.maxSwitchMinutes();
+        if (minMinutes <= 0 || maxMinutes <= 0) {
+            return 0L;
+        }
+        int lower = Math.min(minMinutes, maxMinutes);
+        int upper = Math.max(minMinutes, maxMinutes);
+        if (lower == upper) {
+            return Duration.ofMinutes(lower).toMillis();
+        }
+        int chosenMinutes = lower + random.nextInt(upper - lower + 1);
+        return Duration.ofMinutes(chosenMinutes).toMillis();
+    }
+
+    private void startStageIfNeeded(KSPAutoMinerConfig minerConfig,
+                                    KSPAutoWoodcutterConfig woodcutterConfig,
+                                    AutoFishingConfig fishingConfig,
+                                    GECookerConfig cookerConfig) {
+        if (currentStage == Stage.MINING) {
+            startMiner(minerConfig);
+        } else if (currentStage == Stage.WOODCUTTING) {
+            startWoodcutter(woodcutterConfig);
+        } else if (currentStage == Stage.F2P_FISHING) {
+            startFishing(fishingConfig);
+        } else if (currentStage == Stage.F2P_COOKER) {
+            startCooker(cookerConfig);
+        }
+    }
+
+    private Stage getNextStage(Stage stage) {
+        if (stage == Stage.MINING) {
+            return Stage.WOODCUTTING;
+        }
+        if (stage == Stage.WOODCUTTING) {
+            return Stage.F2P_FISHING;
+        }
+        if (stage == Stage.F2P_FISHING) {
+            return Stage.F2P_COOKER;
+        }
+        return Stage.MINING;
+    }
+
+    private boolean isMiningComplete(KSPAccountBuilderConfig config) {
+        int level = Microbot.getClient().getRealSkillLevel(Skill.MINING);
+        return level >= config.targetMiningLevel();
+    }
+
+    private boolean isWoodcuttingComplete(KSPAccountBuilderConfig config) {
+        int level = Microbot.getClient().getRealSkillLevel(Skill.WOODCUTTING);
+        return level >= config.targetWoodcuttingLevel();
+    }
+
+    private void startMiner(KSPAutoMinerConfig minerConfig) {
+        if (minerRunning) {
+            return;
+        }
+        applyMiningRockForLevel();
+        if (!ensureToolAvailable(true)) {
+            status = "Missing pickaxe";
+            return;
+        }
+        minerScript.run(minerConfig);
+        minerRunning = true;
+    }
+
+    private void startWoodcutter(KSPAutoWoodcutterConfig woodcutterConfig) {
+        if (woodcutterRunning) {
+            return;
+        }
+        applyWoodcuttingTreeForLevel();
+        if (!ensureToolAvailable(false)) {
+            status = "Missing axe";
+            return;
+        }
+        woodcutterScript.run(woodcutterConfig);
+        woodcutterRunning = true;
+    }
+
+    private void stopMiner() {
+        if (!minerRunning) {
+            return;
+        }
+        minerScript.shutdown();
+        minerRunning = false;
+    }
+
+    private void stopWoodcutter() {
+        if (!woodcutterRunning) {
+            return;
+        }
+        woodcutterScript.shutdown();
+        woodcutterRunning = false;
+    }
+
+    private void stopAll() {
+        stopMiner();
+        stopWoodcutter();
+        stopFishing();
+        stopCooker();
+    }
+
+    private void stopCurrentStage() {
+        if (currentStage == Stage.MINING) {
+            stopMiner();
+        } else if (currentStage == Stage.WOODCUTTING) {
+            stopWoodcutter();
+        } else if (currentStage == Stage.F2P_FISHING) {
+            stopFishing();
+        } else if (currentStage == Stage.F2P_COOKER) {
+            stopCooker();
+        }
+    }
+
+    private boolean handleKaramjaExitBeforeSwitch() {
+        if (!isOnKaramja()) {
+            return false;
+        }
+
+        status = "Leaving Karamja";
+        Rs2NpcModel customsOfficer = Rs2Npc.getNpc("Customs officer");
+        if (customsOfficer == null) {
+            Rs2Walker.walkTo(KARAMJA_CUSTOMS_DOCK);
+            return true;
+        }
+
+        int distance = customsOfficer.getWorldLocation().distanceTo(Rs2Player.getWorldLocation());
+        if (distance > 5) {
+            Rs2Walker.walkTo(customsOfficer.getWorldLocation());
+            return true;
+        }
+
+        if (Rs2Npc.interact(customsOfficer, "Pay-fare")
+                || Rs2Npc.interact(customsOfficer, "Pay fare")) {
+            sleepUntil(() -> !isOnKaramja() || isNearPortSarimDock(), 8000);
+        }
+        return isOnKaramja() && !isNearPortSarimDock();
+    }
+
+    private boolean isOnKaramja() {
+        if (Microbot.getClient().getLocalPlayer() == null) {
+            return false;
+        }
+        var location = Microbot.getClient().getLocalPlayer().getWorldLocation();
+        return location.getX() >= 2760 && location.getX() <= 2965
+                && location.getY() >= 3000 && location.getY() <= 3185
+                && location.getPlane() == 0;
+    }
+
+    private boolean isNearPortSarimDock() {
+        if (Microbot.getClient().getLocalPlayer() == null) {
+            return false;
+        }
+        return Microbot.getClient().getLocalPlayer().getWorldLocation().distanceTo(PORT_SARIM_DOCK) <= 12;
+    }
+
+    private void applyMiningRockForLevel() {
+        int miningLevel = Microbot.getClient().getRealSkillLevel(Skill.MINING);
+        List<KSPAutoMinerRock> availableRocks = Arrays.stream(KSPAutoMinerRock.values())
+                .filter(rock -> miningLevel >= rock.getMiningLevel())
+                .collect(java.util.stream.Collectors.toList());
+        if (availableRocks.isEmpty()) {
+            configManager.setConfiguration("KSPAutoMiner", "rock", KSPAutoMinerRock.COPPER_TIN);
+            return;
+        }
+        KSPAutoMinerRock selected = availableRocks.get(random.nextInt(availableRocks.size()));
+        configManager.setConfiguration("KSPAutoMiner", "rock", selected);
+    }
+
+    private void applyWoodcuttingTreeForLevel() {
+        int woodcuttingLevel = Microbot.getClient().getRealSkillLevel(Skill.WOODCUTTING);
+        List<KSPAutoWoodcutterTree> availableTrees = Arrays.stream(KSPAutoWoodcutterTree.values())
+                .filter(tree -> woodcuttingLevel >= tree.getWoodcuttingLevel())
+                .collect(java.util.stream.Collectors.toList());
+        if (availableTrees.isEmpty()) {
+            configManager.setConfiguration("KSPAutoWoodcutter", "tree", KSPAutoWoodcutterTree.TREE);
+            return;
+        }
+        KSPAutoWoodcutterTree selected = availableTrees.get(random.nextInt(availableTrees.size()));
+        configManager.setConfiguration("KSPAutoWoodcutter", "tree", selected);
+    }
+
+    private void applyFishingForLevel() {
+        int fishingLevel = Microbot.getClient().getRealSkillLevel(Skill.FISHING);
+        List<F2PFishOption> availableFish = Arrays.stream(F2PFishOption.values())
+                .filter(option -> fishingLevel >= option.requiredLevel)
+                .collect(java.util.stream.Collectors.toList());
+
+        Fish selected = availableFish.isEmpty()
+                ? Fish.SHRIMP_AND_ANCHOVIES
+                : availableFish.get(random.nextInt(availableFish.size())).fish;
+
+        configManager.setConfiguration("AutoFishing", "fishToCatch", selected);
+    }
+
+    private void startFishing(AutoFishingConfig fishingConfig) {
+        if (fishingRunning) {
+            return;
+        }
+        applyFishingForLevel();
+        fishingScript.run(fishingConfig);
+        fishingRunning = true;
+    }
+
+    private void stopFishing() {
+        if (!fishingRunning) {
+            return;
+        }
+        fishingScript.shutdown();
+        fishingRunning = false;
+    }
+
+
+    private void applyCookingForLevel() {
+        int cookingLevel = Microbot.getClient().getRealSkillLevel(Skill.COOKING);
+        List<F2PCookOption> availableItems = Arrays.stream(F2PCookOption.values())
+                .filter(option -> cookingLevel >= option.requiredLevel)
+                .collect(java.util.stream.Collectors.toList());
+
+        CookingItem selected = availableItems.isEmpty()
+                ? CookingItem.RAW_SHRIMP
+                : availableItems.get(random.nextInt(availableItems.size())).cookingItem;
+
+        configManager.setConfiguration("GECooker", "Cook Item", selected);
+    }
+
+    private void startCooker(GECookerConfig cookerConfig) {
+        if (cookerRunning) {
+            return;
+        }
+        applyCookingForLevel();
+        cookerScript.run(cookerConfig);
+        cookerRunning = true;
+    }
+
+    private void stopCooker() {
+        if (!cookerRunning) {
+            return;
+        }
+        cookerScript.shutdown();
+        cookerRunning = false;
+    }
+
+    private boolean ensureToolAvailable(boolean miningStage) {
+        if (!Microbot.isLoggedIn() || Microbot.getClient().getLocalPlayer() == null) {
+            return false;
+        }
+        long now = System.currentTimeMillis();
+        if (now < nextToolCheckMs) {
+            return false;
+        }
+        ToolRequirement requirement = getBestToolOnPlayer(miningStage);
+        if (requirement != null) {
+            nextToolCheckMs = 0L;
+            return true;
+        }
+        if (!Rs2Bank.isOpen()) {
+            if (!Rs2Bank.walkToBankAndUseBank()) {
+                nextToolCheckMs = now + TOOL_CHECK_COOLDOWN_MS;
+                return false;
+            }
+        }
+        if (!Rs2Bank.isOpen()) {
+            nextToolCheckMs = now + TOOL_CHECK_COOLDOWN_MS;
+            return false;
+        }
+        Rs2ItemModel bestFromBank = getBestToolFromBank(miningStage);
+        if (bestFromBank == null) {
+            Rs2Bank.closeBank();
+            nextToolCheckMs = now + TOOL_CHECK_COOLDOWN_MS;
+            return false;
+        }
+        if (getAttackLevel(bestFromBank.getId(), miningStage) > 1 && canEquipTool(bestFromBank.getId(), miningStage)) {
+            Rs2ItemModel currentWeapon = Rs2Equipment.get(EquipmentInventorySlot.WEAPON);
+            Rs2Bank.withdrawAndEquip(bestFromBank.getId());
+            if (currentWeapon != null && currentWeapon.getId() != bestFromBank.getId()) {
+                Rs2Bank.depositOne(currentWeapon.getId());
+            }
+        } else {
+            if (!Rs2Inventory.hasItem(bestFromBank.getId())) {
+                Rs2Bank.withdrawOne(bestFromBank.getId());
+            }
+        }
+        Rs2Inventory.waitForInventoryChanges(2000);
+        boolean hasTool = getBestToolOnPlayer(miningStage) != null;
+        if (hasTool) {
+            Rs2Bank.closeBank();
+            nextToolCheckMs = 0L;
+            return true;
+        }
+        nextToolCheckMs = now + TOOL_CHECK_COOLDOWN_MS;
+        return false;
+    }
+
+    private ToolRequirement getBestToolOnPlayer(boolean miningStage) {
+        Rs2ItemModel equipped = Rs2Equipment.get(EquipmentInventorySlot.WEAPON);
+        if (equipped != null && isValidTool(equipped.getId(), miningStage)) {
+            return getRequirement(equipped.getId(), miningStage);
+        }
+        return Rs2Inventory.items()
+                .filter(item -> isValidTool(item.getId(), miningStage))
+                .max((first, second) -> Integer.compare(
+                        getSkillLevel(first.getId(), miningStage),
+                        getSkillLevel(second.getId(), miningStage)))
+                .map(item -> getRequirement(item.getId(), miningStage))
+                .orElse(null);
+    }
+
+    private Rs2ItemModel getBestToolFromBank(boolean miningStage) {
+        return Rs2Bank.getAll(item -> isValidTool(item.getId(), miningStage))
+                .max((first, second) -> Integer.compare(
+                        getSkillLevel(first.getId(), miningStage),
+                        getSkillLevel(second.getId(), miningStage)))
+                .orElse(null);
+    }
+
+    private boolean isValidTool(int itemId, boolean miningStage) {
+        ToolRequirement requirement = getRequirement(itemId, miningStage);
+        if (requirement == null) {
+            return false;
+        }
+        return Rs2Player.getSkillRequirement(requirement.skill, requirement.skillLevel);
+    }
+
+    private boolean canEquipTool(int itemId, boolean miningStage) {
+        ToolRequirement requirement = getRequirement(itemId, miningStage);
+        if (requirement == null) {
+            return false;
+        }
+        return Rs2Player.getSkillRequirement(Skill.ATTACK, requirement.attackLevel);
+    }
+
+    private int getSkillLevel(int itemId, boolean miningStage) {
+        ToolRequirement requirement = getRequirement(itemId, miningStage);
+        return requirement != null ? requirement.skillLevel : 0;
+    }
+
+    private int getAttackLevel(int itemId, boolean miningStage) {
+        ToolRequirement requirement = getRequirement(itemId, miningStage);
+        return requirement != null ? requirement.attackLevel : 0;
+    }
+
+    private ToolRequirement getRequirement(int itemId, boolean miningStage) {
+        List<ToolRequirement> requirements = miningStage ? PICKAXE_REQUIREMENTS : AXE_REQUIREMENTS;
+        return requirements.stream()
+                .filter(requirement -> requirement.itemId == itemId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static final class ToolRequirement {
+        private final int itemId;
+        private final int skillLevel;
+        private final int attackLevel;
+        private final Skill skill;
+
+        private ToolRequirement(int itemId, int skillLevel, int attackLevel, Skill skill) {
+            this.itemId = itemId;
+            this.skillLevel = skillLevel;
+            this.attackLevel = attackLevel;
+            this.skill = skill;
+        }
+    }
+
+    private enum F2PFishOption {
+        SHRIMP(Fish.SHRIMP_AND_ANCHOVIES, 1),
+        SARDINE(Fish.SARDINE, 5),
+        HERRING(Fish.HERRING, 10),
+        TROUT_SALMON(Fish.TROUT_AND_SALMON, 20),
+        LOBSTER(Fish.LOBSTER, 40),
+        TUNA_SWORDFISH(Fish.TUNA_AND_SWORDFISH, 50);
+
+        private final Fish fish;
+        private final int requiredLevel;
+
+        F2PFishOption(Fish fish, int requiredLevel) {
+            this.fish = fish;
+            this.requiredLevel = requiredLevel;
+        }
+    }
+
+    private enum F2PCookOption {
+        SHRIMP(CookingItem.RAW_SHRIMP, 1),
+        HERRING(CookingItem.RAW_HERRING, 5),
+        TROUT(CookingItem.RAW_TROUT, 15),
+        SALMON(CookingItem.RAW_SALMON, 25),
+        TUNA(CookingItem.RAW_TUNA, 30),
+        LOBSTER(CookingItem.RAW_LOBSTER, 40),
+        SWORDFISH(CookingItem.RAW_SWORDFISH, 45);
+
+        private final CookingItem cookingItem;
+        private final int requiredLevel;
+
+        F2PCookOption(CookingItem cookingItem, int requiredLevel) {
+            this.cookingItem = cookingItem;
+            this.requiredLevel = requiredLevel;
+        }
+    }
+
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderStartSkill.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/KSPAccountBuilder/KSPAccountBuilderStartSkill.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.KSPAccountBuilder;
+
+public enum KSPAccountBuilderStartSkill {
+    MINING,
+    WOODCUTTING,
+    F2P_FISHING,
+    F2P_COOKER,
+    RANDOM
+}


### PR DESCRIPTION
### Motivation
- Add support for training F2P Cooking as part of the account builder's rotation so accounts can be built with a cooking phase using the existing GE cooker plugin.
- Make the cooker selectable as a `startSkill` and include it in random/start selection and timed stage rotation. 
- Automatically pick an appropriate F2P cooking item for the GE cooker based on the player's Cooking level before starting the cooker stage.

### Description
- Add `F2P_COOKER` to `KSPAccountBuilderStartSkill` so cooker mode can be selected via `startSkill` (`KSPAccountBuilderStartSkill.F2P_COOKER`).
- Wire `GECookerConfig` into `KSPAccountBuilderPlugin` by injecting the config, adding a `@Provides` method, bumping the plugin `version` to `0.3.3`, and passing the cooker config to the script at startup (`script.run(..., cookerConfig)`).
- Extend `KSPAccountBuilderScript` with imports for `GECookerConfig`, `GECookerScript`, and `CookingItem`, add a `cookerRunning` flag and a `F2P_COOKER` stage, update the `run` signature to accept `GECookerConfig`, include the cooker in random/explicit start selection and time-based switching, and add lifecycle handling to start/stop the cooker stage.
- Implement `applyCookingForLevel()` which selects a cooking item from a new `F2PCookOption` enum based on the player's Cooking level and writes the selection into the GE cooker configuration via `configManager.setConfiguration("GECooker", "Cook Item", selected)` before starting the cooker; add `startCooker()` and `stopCooker()` helpers and include cooker in `startStageIfNeeded`, `getNextStage`, `stopAll`, and `stopCurrentStage` flows.

### Testing
- Attempted to compile with `./gradlew -q compileJava`, but the Gradle wrapper failed to download dependencies in this environment due to a proxy error (`HTTP/1.1 403 Forbidden`), so compilation could not be completed here.
- Changes were committed locally and the commit was created successfully (`feat: add f2p cooker stage to ksp account builder`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c6b9b45483308ab013fa56100465)