### PR TITLE
feat: add KSPMelee status overlay and runtime/status tracking

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeConfig.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.microbot.kspmelee;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("kspmelee")
+public interface KSPMeleeConfig extends Config {
+
+    @ConfigItem(
+            keyName = "instructions",
+            name = "Instructions",
+            description = "How to use this plugin",
+            position = 0
+    )
+    default String instructions() {
+        return "1. Start the plugin from anywhere in F2P.\n"
+                + "2. If Attack is below 5, it buys a Bronze/Iron scimitar at the GE.\n"
+                + "3. If Defence is below 5, it buys Bronze/Iron platebody, full helm, platelegs, and kiteshield.\n"
+                + "4. If you do not have an Amulet of power in bank/inventory, it buys one.";
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeOverlay.java
@@ -1,0 +1,49 @@
+package net.runelite.client.plugins.microbot.kspmelee;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+
+public class KSPMeleeOverlay extends OverlayPanel {
+
+    private final KSPMeleeScript script;
+
+    @Inject
+    KSPMeleeOverlay(KSPMeleePlugin plugin, KSPMeleeScript script) {
+        super(plugin);
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(220, 120));
+
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("KSP Melee")
+                .color(Color.GREEN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder().build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status:")
+                .right(script.getStatus())
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time Running:")
+                .right(script.getRunningTime())
+                .build());
+
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleePlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleePlugin.java
@@ -1,0 +1,59 @@
+package net.runelite.client.plugins.microbot.kspmelee;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginConstants.KSP + "Melee",
+        description = "Basic melee combat framework plugin.",
+        tags = {"melee", "combat", "ksp"},
+        authors = {"KSP"},
+        version = KSPMeleePlugin.version,
+        minClientVersion = "1.9.8",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KSPMeleePlugin extends Plugin {
+
+    static final String version = "1.0.5";
+
+    @Inject
+    private KSPMeleeConfig config;
+
+    @Inject
+    private KSPMeleeScript script;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private KSPMeleeOverlay overlay;
+
+    @Provides
+    KSPMeleeConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPMeleeConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspmelee/KSPMeleeScript.java
@@ -1,0 +1,268 @@
+package net.runelite.client.plugins.microbot.kspmelee;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+@Slf4j
+public class KSPMeleeScript extends Script {
+
+    private static final String IRON_SCIMITAR = "Iron scimitar";
+    private static final String BRONZE_SCIMITAR = "Bronze scimitar";
+    private static final String IRON_PLATEBODY = "Iron platebody";
+    private static final String BRONZE_PLATEBODY = "Bronze platebody";
+    private static final String IRON_FULL_HELM = "Iron full helm";
+    private static final String BRONZE_FULL_HELM = "Bronze full helm";
+    private static final String IRON_PLATELEGS = "Iron platelegs";
+    private static final String BRONZE_PLATELEGS = "Bronze platelegs";
+    private static final String IRON_KITESHIELD = "Iron kiteshield";
+    private static final String BRONZE_KITESHIELD = "Bronze kiteshield";
+    private static final String AMULET_OF_POWER = "Amulet of power";
+    private static final int BUY_WAIT_TIMEOUT_MS = 20000;
+
+    private boolean setupDone;
+    private Instant startedAt;
+    private String status = "Idle";
+
+    public boolean run(KSPMeleeConfig config) {
+        setupDone = false;
+        startedAt = Instant.now();
+        status = "Starting";
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    return;
+                }
+
+                if (!super.run()) {
+                    return;
+                }
+
+                if (setupDone) {
+                    status = "Ready";
+                    return;
+                }
+
+                if (ensureStarterMeleeGear()) {
+                    setupDone = true;
+                    status = "Setup complete";
+                    log.info("KSPMelee: Starter gear setup complete.");
+                }
+            } catch (Exception ex) {
+                log.error("KSPMelee script error", ex);
+            }
+        }, 0, 1200, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    private boolean ensureStarterMeleeGear() {
+        status = "Checking bank";
+        if (!refreshBankItems()) {
+            return false;
+        }
+
+        int attackLevel = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
+        int defenceLevel = Microbot.getClient().getRealSkillLevel(Skill.DEFENCE);
+
+        List<PurchaseRequest> purchases = new ArrayList<>();
+
+        if (attackLevel < 5 && !hasItemAnywhere(IRON_SCIMITAR, BRONZE_SCIMITAR)) {
+            purchases.add(new PurchaseRequest(IRON_SCIMITAR, BRONZE_SCIMITAR));
+        }
+
+        if (defenceLevel < 5) {
+            addIfMissing(purchases, IRON_PLATEBODY, BRONZE_PLATEBODY);
+            addIfMissing(purchases, IRON_FULL_HELM, BRONZE_FULL_HELM);
+            addIfMissing(purchases, IRON_PLATELEGS, BRONZE_PLATELEGS);
+            addIfMissing(purchases, IRON_KITESHIELD, BRONZE_KITESHIELD);
+        }
+
+        if (!hasItemAnywhere(AMULET_OF_POWER)) {
+            purchases.add(new PurchaseRequest(AMULET_OF_POWER));
+        }
+
+        if (purchases.isEmpty()) {
+            status = "No purchases needed";
+            return true;
+        }
+
+        status = "Buying supplies";
+        return buyFromGrandExchange(purchases);
+    }
+
+    private void addIfMissing(List<PurchaseRequest> purchases, String primary, String fallback) {
+        if (!hasItemAnywhere(primary, fallback)) {
+            purchases.add(new PurchaseRequest(primary, fallback));
+        }
+    }
+
+    private boolean hasItemAnywhere(String... names) {
+        for (String name : names) {
+            if (Rs2Inventory.hasItem(name, true) || countBankItem(name) > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int countBankItem(String itemName) {
+        return Rs2Bank.bankItems().stream()
+                .filter(item -> item.getName() != null && item.getName().equalsIgnoreCase(itemName))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
+    }
+
+    private boolean refreshBankItems() {
+        if (Rs2Bank.isOpen()) {
+            return true;
+        }
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5000);
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 3000);
+        return true;
+    }
+
+    private boolean buyFromGrandExchange(List<PurchaseRequest> purchases) {
+        if (!Rs2GrandExchange.walkToGrandExchange()) {
+            return false;
+        }
+
+        if (!Rs2GrandExchange.openExchange()) {
+            return false;
+        }
+
+        sleepUntil(Rs2GrandExchange::isOpen, 7000);
+        if (!Rs2GrandExchange.isOpen()) {
+            return false;
+        }
+
+        for (PurchaseRequest purchase : purchases) {
+            if (alreadyOwned(purchase)) {
+                continue;
+            }
+
+            if (!ensureExchangeSlotAvailable()) {
+                log.warn("KSPMelee: No GE slot available for {}.", purchase.primary);
+                continue;
+            }
+
+            if (!placeBuyOffer(purchase.primary)) {
+                collectBoughtOffers();
+
+                if (alreadyOwned(purchase)) {
+                    continue;
+                }
+
+                if (purchase.fallback == null || !placeBuyOffer(purchase.fallback)) {
+                    log.warn("KSPMelee: Failed buying {}{}.", purchase.primary,
+                            purchase.fallback == null ? "" : " (fallback: " + purchase.fallback + ")");
+                }
+            }
+
+            waitForPurchaseCompletion(purchase);
+
+            collectBoughtOffers();
+        }
+
+        collectBoughtOffers();
+
+        Rs2GrandExchange.closeExchange();
+        return true;
+    }
+
+    private boolean alreadyOwned(PurchaseRequest purchase) {
+        return hasItemAnywhere(purchase.primary) || (purchase.fallback != null && hasItemAnywhere(purchase.fallback));
+    }
+
+    private boolean ensureExchangeSlotAvailable() {
+        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
+            return true;
+        }
+
+        collectBoughtOffers();
+
+        sleepUntil(() -> Rs2GrandExchange.getAvailableSlotsCount() > 0, 5000);
+        return Rs2GrandExchange.getAvailableSlotsCount() > 0;
+    }
+
+    private void collectBoughtOffers() {
+        if (!Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer()) {
+            return;
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
+    }
+
+    private boolean placeBuyOffer(String itemName) {
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(GrandExchangeAction.BUY)
+                .itemName(itemName)
+                .quantity(1)
+                .percent(8)
+                .closeAfterCompletion(false)
+                .build();
+
+        boolean offered = Rs2GrandExchange.processOffer(request);
+        sleepUntil(Rs2GrandExchange::isOpen, 3000);
+        return offered;
+    }
+
+    private void waitForPurchaseCompletion(PurchaseRequest purchase) {
+        sleepUntil(() -> alreadyOwned(purchase)
+                || Rs2GrandExchange.hasBoughtOffer()
+                || !Rs2GrandExchange.isOpen(), BUY_WAIT_TIMEOUT_MS);
+    }
+
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getRunningTime() {
+        if (startedAt == null) {
+            return "00:00:00";
+        }
+
+        Duration duration = Duration.between(startedAt, Instant.now());
+        long hours = duration.toHours();
+        long minutes = duration.toMinutesPart();
+        long seconds = duration.toSecondsPart();
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+
+    private static class PurchaseRequest {
+        private final String primary;
+        private final String fallback;
+
+        private PurchaseRequest(String primary) {
+            this(primary, null);
+        }
+
+        private PurchaseRequest(String primary, String fallback) {
+            this.primary = primary;
+            this.fallback = fallback;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an on-screen status panel so users can see the KSP Melee script state and runtime at a glance. 
- Surface the script `status` and elapsed run time to aid debugging and confirm progress during automated Grand Exchange purchases. 
- Keep Grand Exchange purchases reliable by waiting for ownership/bought-offer signals before proceeding. 

### Description
- Added a new `KSPMeleeOverlay` that displays a centered title `KSP Melee` and two rows for `Status:` and `Time Running:`. 
- Exposed runtime and state from the script by adding `startedAt`, `status`, `getStatus()` and `getRunningTime()` to `KSPMeleeScript`, and updated script flow to set `status` at key points. 
- Wired overlay lifecycle into the plugin by registering the overlay with `OverlayManager` on `startUp()` and removing it on `shutDown()` in `KSPMeleePlugin`. 
- Added `KSPMeleeConfig` with basic instructions and bumped plugin version to `1.0.5`, and preserved the bounded wait helper `waitForPurchaseCompletion` used during GE buys. 

### Testing
- Attempted `./gradlew build -PpluginList=KSPMeleePlugin` to build the plugin, but the Gradle wrapper download was blocked by the environment proxy (`HTTP 403`) so automated build/tests did not complete. 
- No unit tests were added or executed as part of this change due to the build environment limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d171b045883309adfc99bf2e68a96)