### PR TITLE
feat: add SILVER mining area and bump KSPAccountBuilderPlugin version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("kspaccountbuilder")
+public interface KSPAccountBuilderConfig extends Config {
+
+    @ConfigItem(
+            keyName = "instructions",
+            name = "Instructions",
+            description = "High-level usage instructions for the plugin skeleton",
+            position = 0
+    )
+    default String instructions() {
+        return "KSP Account Builder skeleton is active. Add tasks and progression logic in KSPAccountBuilderScript.";
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -1,0 +1,50 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+
+@PluginDescriptor(
+        name = PluginConstants.KSP + "Account Builder",
+        description = "Skeleton plugin for automated account progression workflows.",
+        tags = {"ksp", "account", "builder"},
+        authors = {"KSP"},
+        version = KSPAccountBuilderPlugin.version,
+        minClientVersion = "1.9.8",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KSPAccountBuilderPlugin extends Plugin {
+
+    static final String version = "1.0.6";
+
+    @Inject
+    private KSPAccountBuilderConfig config;
+
+    @Inject
+    private KSPAccountBuilderScript script;
+
+    @Provides
+    KSPAccountBuilderConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPAccountBuilderConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        log.info("Starting KSP Account Builder skeleton.");
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        log.info("Stopping KSP Account Builder skeleton.");
+        script.shutdown();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -1,0 +1,56 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.mining.script.MiningSetup;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class KSPAccountBuilderScript extends Script {
+
+    @Getter
+    private String status = "Idle";
+
+    private final MiningSetup miningSetup = new MiningSetup();
+
+    public boolean run(KSPAccountBuilderConfig config) {
+        status = "Starting";
+        miningSetup.initialize();
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn()) {
+                    status = "Waiting for login";
+                    return;
+                }
+
+                if (!super.run()) {
+                    return;
+                }
+
+                status = "Skeleton active";
+                // TODO: Wire mining setup into account progression workflow.
+                if (!miningSetup.hasRequiredTools()) {
+                    return;
+                }
+
+                miningSetup.execute();
+            } catch (Exception ex) {
+                status = "Error";
+                log.error("KSPAccountBuilder encountered an error", ex);
+            }
+        }, 0, 1000, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown() {
+        status = "Stopped";
+        miningSetup.shutdown();
+        super.shutdown();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/mining/areas/Areas.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/mining/areas/Areas.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.mining.areas;
+
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+
+/**
+ * Skeleton mining areas used by KSPAccountBuilder.
+ */
+public final class Areas {
+
+    private Areas() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Varrock mine section with Copper, Tin, and Iron rocks.
+     * Bounds: (3281,3370) to (3290,3359), plane 0.
+     */
+    public static final WorldArea COPPER_TIN_IRON =
+            new WorldArea(new WorldPoint(3281, 3359, 0), 10, 12);
+
+    /**
+     * Coal mining section bounds: (3075,3424) to (3085,3416), plane 0.
+     */
+    public static final WorldArea COAL =
+            new WorldArea(new WorldPoint(3075, 3416, 0), 11, 9);
+
+    /**
+     * Silver mining section bounds: (3169,3372) to (3183,3363), plane 0.
+     */
+    public static final WorldArea SILVER =
+            new WorldArea(new WorldPoint(3169, 3363, 0), 15, 10);
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/mining/script/MiningSetup.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/mining/script/MiningSetup.java
@@ -1,0 +1,43 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.mining.script;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Skeleton mining setup for KSPAccountBuilder.
+ * <p>
+ * This class is intentionally minimal and only defines the structure
+ * needed for future mining progression implementation.
+ */
+@Slf4j
+@Getter
+public class MiningSetup {
+
+    private MiningState state = MiningState.NOT_STARTED;
+
+    public void initialize() {
+        state = MiningState.INITIALIZING;
+        log.info("MiningSetup skeleton initialized.");
+    }
+
+    public boolean hasRequiredTools() {
+        // TODO: Add validation for pickaxe, inventory space, and transport requirements.
+        return false;
+    }
+
+    public void execute() {
+        state = MiningState.RUNNING;
+        // TODO: Add mining route selection and action loop.
+    }
+
+    public void shutdown() {
+        state = MiningState.STOPPED;
+    }
+
+    public enum MiningState {
+        NOT_STARTED,
+        INITIALIZING,
+        RUNNING,
+        STOPPED
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide the requested silver mining area so mining scripts can reference the correct region. 
- Keep the KSP Account Builder plugin skeleton version consistent after the area addition.

### Description
- Add `SILVER` area constant to `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.mining.areas.Areas` with bounds `(3169,3372)` to `(3183,3363)` on plane `0` implemented as `new WorldArea(new WorldPoint(3169, 3363, 0), 15, 10)`.
- Bump `KSPAccountBuilderPlugin` `version` constant from `"1.0.5"` to `"1.0.6"` in `KSPAccountBuilderPlugin.java` to reflect the change.
- Change is metadata-only for the mining area and leaves the existing skeleton plugin code unchanged functionally.

### Testing
- Attempted `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, but the Gradle wrapper download failed due to an environment proxy error (`HTTP/1.1 403 Forbidden`), so a full build could not be completed.
- Confirmed the new `SILVER` constant and version bump are present in the modified source files via local inspection commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990004652f08330a54365e8362d21df)