### PR TITLE
feat(kspaccountbuilder): add TreeLevels utility with YEW = 60

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
@@ -1,0 +1,17 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels;
+
+/**
+ * Woodcutting level requirements used by KSPAccountBuilder.
+ */
+public final class TreeLevels {
+
+    private TreeLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TREE = 1;
+    public static final int OAK = 15;
+    public static final int WILLOW = 30;
+    public static final int MAPLE = 45;
+    public static final int YEW = 60;
+}


### PR DESCRIPTION
### Motivation
- Provide a centralized set of woodcutting level requirement constants for the KSPAccountBuilder workflow so tree requirements (including Yew) can be referenced consistently.

### Description
- Add new utility class `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java` defining `TREE`, `OAK`, `WILLOW`, `MAPLE`, and `YEW` constants with `YEW = 60`.

### Testing
- Attempted to run `bash ./gradlew build -PpluginList=KSPAccountBuilderPlugin -x test` but the build could not complete in this environment because the Gradle wrapper download was blocked by a proxy (`HTTP/1.1 403 Forbidden`) and invoking `./gradlew` directly returned `Permission denied`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfcd3c5c8330949e566418460289)