### PR TITLE
fix: remove MAPLE constant from TreeLevels

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels;
+
+/**
+ * Woodcutting level requirements used by KSPAccountBuilder.
+ */
+public final class TreeLevels {
+
+    private TreeLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TREE = 1;
+    public static final int OAK = 15;
+    public static final int WILLOW = 30;
+    public static final int YEW = 60;
+}


### PR DESCRIPTION
### Motivation
- Remove `MAPLE` level from the KSPAccountBuilder woodcutting constants as requested in review.

### Description
- Delete `public static final int MAPLE = 45;` from `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java`, leaving `TREE`, `OAK`, `WILLOW`, and `YEW` (`YEW = 60`).

### Testing
- Verified the change with `git diff -- src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java` and `nl -ba src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java`; no automated build or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfcd3c5c8330949e566418460289)