### PR TITLE
feat: add woodcutting TreeLevels and axe equip/equipment level constants

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels;
+
+/**
+ * Woodcutting level requirements used by KSPAccountBuilder.
+ */
+public final class TreeLevels {
+
+    private TreeLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TREE = 1;
+    public static final int OAK = 15;
+    public static final int WILLOW = 30;
+    public static final int YEW = 60;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Woodcutting level requirements for axes used by KSPAccountBuilder.
+ */
+public final class AxeWCLevels {
+
+    private AxeWCLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 6;
+    public static final int BLACK_AXE = 11;
+    public static final int MITHRIL_AXE = 21;
+    public static final int ADAMANT_AXE = 31;
+    public static final int RUNE_AXE = 41;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Attack level requirements to equip axes for KSPAccountBuilder.
+ */
+public final class EquipLevels {
+
+    private EquipLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 5;
+    public static final int BLACK_AXE = 10;
+    public static final int MITHRIL_AXE = 20;
+    public static final int ADAMANT_AXE = 30;
+    public static final int RUNE_AXE = 40;
+}


### PR DESCRIPTION
### Motivation
- Provide centralized constants for KSPAccountBuilder to reference woodcutting tree level requirements and axe equip/usage requirements. 
- Separate attack `equip` level requirements from woodcutting `use` levels to avoid hardcoding values across plugins.

### Description
- Added `TreeLevels` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels` with constants `TREE`, `OAK`, `WILLOW`, and `YEW`. 
- Added `AxeWCLevels` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools` with woodcutting level requirements for each axe. 
- Added `EquipLevels` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools` with attack level requirements to equip each axe. 
- Each class is a final utility class with a private constructor to prevent instantiation. 

### Testing
- Verified file contents with `nl -ba src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java` and `nl -ba src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/{AxeWCLevels.java,EquipLevels.java}` and confirmed the declared constants. 
- Ran `git status --short` to confirm files were added and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfcd3c5c8330949e566418460289)