### PR TITLE
feat: add woodcutting level constants and GE Buy helper for missing axes

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/Buy.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/Buy.java
@@ -1,0 +1,143 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.ge;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+/**
+ * Grand Exchange buying helpers for KSPAccountBuilder.
+ */
+@Slf4j
+public final class Buy {
+
+    private static final int BUY_WAIT_TIMEOUT_MS = 20000;
+    private static final List<String> AXE_NAMES = List.of(
+            "Bronze axe",
+            "Steel axe",
+            "Black axe",
+            "Mithril axe",
+            "Adamant axe",
+            "Rune axe"
+    );
+
+    private Buy() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static boolean buyMissingAxes() {
+        if (!refreshBankItems()) {
+            return false;
+        }
+
+        List<String> missingAxes = new ArrayList<>();
+        for (String axe : AXE_NAMES) {
+            if (!hasAxe(axe)) {
+                missingAxes.add(axe);
+            }
+        }
+
+        if (missingAxes.isEmpty()) {
+            return true;
+        }
+
+        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
+            return false;
+        }
+
+        sleepUntil(Rs2GrandExchange::isOpen, 7000);
+        if (!Rs2GrandExchange.isOpen()) {
+            return false;
+        }
+
+        for (String axe : missingAxes) {
+            if (hasAxe(axe)) {
+                continue;
+            }
+
+            if (!ensureExchangeSlotAvailable()) {
+                log.warn("Buy: No GE slot available for {}.", axe);
+                continue;
+            }
+
+            if (!placeBuyOffer(axe)) {
+                log.warn("Buy: Failed placing buy offer for {}.", axe);
+                continue;
+            }
+
+            sleepUntil(() -> hasAxe(axe) || Rs2GrandExchange.hasBoughtOffer() || !Rs2GrandExchange.isOpen(), BUY_WAIT_TIMEOUT_MS);
+            collectOffersToBank();
+        }
+
+        collectOffersToBank();
+        Rs2GrandExchange.closeExchange();
+        return true;
+    }
+
+    private static boolean refreshBankItems() {
+        if (Rs2Bank.isOpen()) {
+            return true;
+        }
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5000);
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 3000);
+        return true;
+    }
+
+    private static boolean hasAxe(String axeName) {
+        return Rs2Inventory.hasItem(axeName, true) || countBankItem(axeName) > 0;
+    }
+
+    private static int countBankItem(String itemName) {
+        return Rs2Bank.bankItems().stream()
+                .filter(item -> item.getName() != null && item.getName().equalsIgnoreCase(itemName))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
+    }
+
+    private static boolean ensureExchangeSlotAvailable() {
+        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
+            return true;
+        }
+
+        collectOffersToBank();
+        sleepUntil(() -> Rs2GrandExchange.getAvailableSlotsCount() > 0, 5000);
+        return Rs2GrandExchange.getAvailableSlotsCount() > 0;
+    }
+
+    private static void collectOffersToBank() {
+        if (!Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer()) {
+            return;
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
+    }
+
+    private static boolean placeBuyOffer(String itemName) {
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(GrandExchangeAction.BUY)
+                .itemName(itemName)
+                .quantity(1)
+                .percent(8)
+                .closeAfterCompletion(false)
+                .build();
+
+        boolean offered = Rs2GrandExchange.processOffer(request);
+        sleepUntil(Rs2GrandExchange::isOpen, 3000);
+        return offered;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels;
+
+/**
+ * Woodcutting level requirements used by KSPAccountBuilder.
+ */
+public final class TreeLevels {
+
+    private TreeLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TREE = 1;
+    public static final int OAK = 15;
+    public static final int WILLOW = 30;
+    public static final int YEW = 60;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Woodcutting level requirements for axes used by KSPAccountBuilder.
+ */
+public final class AxeWCLevels {
+
+    private AxeWCLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 6;
+    public static final int BLACK_AXE = 11;
+    public static final int MITHRIL_AXE = 21;
+    public static final int ADAMANT_AXE = 31;
+    public static final int RUNE_AXE = 41;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Attack level requirements to equip axes for KSPAccountBuilder.
+ */
+public final class EquipLevels {
+
+    private EquipLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 5;
+    public static final int BLACK_AXE = 10;
+    public static final int MITHRIL_AXE = 20;
+    public static final int ADAMANT_AXE = 30;
+    public static final int RUNE_AXE = 40;
+}


### PR DESCRIPTION
### Motivation
- Centralize woodcutting tree and axe level requirements so the KSPAccountBuilder can reference consistent `use` and `equip` thresholds. 
- Provide an automated Grand Exchange helper to ensure starter accounts obtain basic axes when they are missing from inventory/bank.

### Description
- Added final utility classes `TreeLevels`, `AxeWCLevels`, and `EquipLevels` under `kspaccountbuilder.skills.woodcutting` providing constants for tree levels, axe woodcutting `use` levels, and axe attack `equip` levels respectively. 
- Implemented `Buy` utility in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.ge` with `buyMissingAxes()` that refreshes bank state, checks inventory/bank for each axe, walks to the Grand Exchange, places buy offers for missing axes (Bronze/Steel/Black/Mithril/Adamant/Rune), waits for completion, and collects offers to bank. 
- `Buy` includes helpers for bank refresh (`refreshBankItems()`), banking counts (`countBankItem()`), GE slot handling (`ensureExchangeSlotAvailable()`), offer collection (`collectOffersToBank()`), and buy-offer placement (`placeBuyOffer()`).

### Testing
- Verified new files and contents with `nl -ba src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/Buy.java` and `nl -ba` on the three woodcutting level files, which succeeded. 
- Confirmed repository status after changes and created the feature file; local verification commands completed successfully. 
- No automated unit tests were added or run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfcd3c5c8330949e566418460289)