### PR TITLE
feat(kspaccountbuilder): add WoodcuttingScript, wire into main script, add GE Buy helper and woodcutting level constants

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -24,7 +24,7 @@ import java.awt.AWTException;
 public class KSPAccountBuilderPlugin extends Plugin {
 
 
-    static final String version = "0.0.1";
+    static final String version = "0.0.2";
 
     @Inject
     private KSPAccountBuilderConfig config;

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
-
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.mining.script.MiningSetup;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.script.WoodcuttingScript;
 
 import java.util.concurrent.TimeUnit;
 
@@ -15,19 +15,13 @@ public class KSPAccountBuilderScript extends Script {
     @Getter
     private String status = "Idle";
 
-
     private final MiningSetup miningSetup = new MiningSetup();
+    private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
 
     public boolean run(KSPAccountBuilderConfig config) {
         status = "Starting";
         miningSetup.initialize();
-
-
-
-    public boolean run(KSPAccountBuilderConfig config) {
-        status = "Starting";
-
-
+        woodcuttingScript.initialize();
 
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -40,18 +34,17 @@ public class KSPAccountBuilderScript extends Script {
                     return;
                 }
 
-                status = "Skeleton active";
+                status = "KSP Account Builder active";
 
                 // TODO: Wire mining setup into account progression workflow.
-                if (!miningSetup.hasRequiredTools()) {
-                    return;
+                if (miningSetup.hasRequiredTools()) {
+                    miningSetup.execute();
                 }
 
-                miningSetup.execute();
-
-
-
-                // TODO: Implement account progression workflow.
+                // TODO: Wire woodcutting setup into account progression workflow.
+                if (woodcuttingScript.hasRequiredTools()) {
+                    woodcuttingScript.execute();
+                }
             } catch (Exception ex) {
                 status = "Error";
                 log.error("KSPAccountBuilder encountered an error", ex);
@@ -65,6 +58,7 @@ public class KSPAccountBuilderScript extends Script {
     public void shutdown() {
         status = "Stopped";
         miningSetup.shutdown();
+        woodcuttingScript.shutdown();
         super.shutdown();
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
@@ -1,0 +1,147 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.ge.buy;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+/**
+ * Grand Exchange buying helpers for KSPAccountBuilder.
+ */
+@Slf4j
+public final class Buy {
+
+    private static final int BUY_WAIT_TIMEOUT_MS = 20000;
+    private static final List<String> AXE_NAMES = List.of(
+            "Bronze axe",
+            "Steel axe",
+            "Black axe",
+            "Mithril axe",
+            "Adamant axe",
+            "Rune axe"
+    );
+
+    private Buy() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static boolean buyMissingAxes() {
+        if (!refreshBankItems()) {
+            return false;
+        }
+
+        List<String> missingAxes = new ArrayList<>();
+        for (String axe : AXE_NAMES) {
+            if (!hasAxe(axe)) {
+                missingAxes.add(axe);
+            }
+        }
+
+        if (missingAxes.isEmpty()) {
+            return true;
+        }
+
+        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
+            return false;
+        }
+
+        sleepUntil(Rs2GrandExchange::isOpen, 7000);
+        if (!Rs2GrandExchange.isOpen()) {
+            return false;
+        }
+
+        for (String axe : missingAxes) {
+            if (hasAxe(axe)) {
+                continue;
+            }
+
+            if (!ensureExchangeSlotAvailable()) {
+                log.warn("Buy: No GE slot available for {}.", axe);
+                continue;
+            }
+
+            if (!placeBuyOffer(axe)) {
+                log.warn("Buy: Failed placing buy offer for {}.", axe);
+                continue;
+            }
+
+            boolean offerFinished = sleepUntil(Rs2GrandExchange::hasFinishedBuyingOffers, BUY_WAIT_TIMEOUT_MS);
+            if (!offerFinished) {
+                log.warn("Buy: Timed out waiting for buy offer to finish for {}.", axe);
+            }
+
+            collectOffersToBank();
+        }
+
+        collectOffersToBank();
+        Rs2GrandExchange.closeExchange();
+        return true;
+    }
+
+    private static boolean refreshBankItems() {
+        if (Rs2Bank.isOpen()) {
+            return true;
+        }
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5000);
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 3000);
+        return true;
+    }
+
+    private static boolean hasAxe(String axeName) {
+        return Rs2Inventory.hasItem(axeName, true) || countBankItem(axeName) > 0;
+    }
+
+    private static int countBankItem(String itemName) {
+        return Rs2Bank.bankItems().stream()
+                .filter(item -> item.getName() != null && item.getName().equalsIgnoreCase(itemName))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
+    }
+
+    private static boolean ensureExchangeSlotAvailable() {
+        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
+            return true;
+        }
+
+        collectOffersToBank();
+        sleepUntil(() -> Rs2GrandExchange.getAvailableSlotsCount() > 0, 5000);
+        return Rs2GrandExchange.getAvailableSlotsCount() > 0;
+    }
+
+    private static void collectOffersToBank() {
+        if (!Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer()) {
+            return;
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
+    }
+
+    private static boolean placeBuyOffer(String itemName) {
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(GrandExchangeAction.BUY)
+                .itemName(itemName)
+                .quantity(1)
+                .percent(8)
+                .closeAfterCompletion(false)
+                .build();
+
+        boolean offered = Rs2GrandExchange.processOffer(request);
+        sleepUntil(Rs2GrandExchange::isOpen, 3000);
+        return offered;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/levels/TreeLevels.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels;
+
+/**
+ * Woodcutting level requirements used by KSPAccountBuilder.
+ */
+public final class TreeLevels {
+
+    private TreeLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TREE = 1;
+    public static final int OAK = 15;
+    public static final int WILLOW = 30;
+    public static final int YEW = 60;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -1,0 +1,40 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.script;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Skeleton woodcutting workflow for KSPAccountBuilder.
+ */
+@Slf4j
+@Getter
+public class WoodcuttingScript {
+
+    private WoodcuttingState state = WoodcuttingState.NOT_STARTED;
+
+    public void initialize() {
+        state = WoodcuttingState.INITIALIZING;
+        log.info("WoodcuttingScript skeleton initialized.");
+    }
+
+    public boolean hasRequiredTools() {
+        // TODO: Validate required axe/tool availability and travel needs.
+        return false;
+    }
+
+    public void execute() {
+        state = WoodcuttingState.RUNNING;
+        // TODO: Add tree selection and cutting workflow.
+    }
+
+    public void shutdown() {
+        state = WoodcuttingState.STOPPED;
+    }
+
+    public enum WoodcuttingState {
+        NOT_STARTED,
+        INITIALIZING,
+        RUNNING,
+        STOPPED
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/AxeWCLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Woodcutting level requirements for axes used by KSPAccountBuilder.
+ */
+public final class AxeWCLevels {
+
+    private AxeWCLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 6;
+    public static final int BLACK_AXE = 11;
+    public static final int MITHRIL_AXE = 21;
+    public static final int ADAMANT_AXE = 31;
+    public static final int RUNE_AXE = 41;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/tools/EquipLevels.java
@@ -1,0 +1,18 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools;
+
+/**
+ * Attack level requirements to equip axes for KSPAccountBuilder.
+ */
+public final class EquipLevels {
+
+    private EquipLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = 1;
+    public static final int STEEL_AXE = 5;
+    public static final int BLACK_AXE = 10;
+    public static final int MITHRIL_AXE = 20;
+    public static final int ADAMANT_AXE = 30;
+    public static final int RUNE_AXE = 40;
+}


### PR DESCRIPTION
### Motivation
- Provide a pluggable woodcutting workflow for the KSP account progression skeleton so woodcutting can run alongside mining in a single scheduler loop. 
- Centralize woodcutting/axe level requirements so account builder logic can reference consistent thresholds. 
- Add Grand Exchange buy helpers that robustly wait for offer completion to avoid collecting offers too early and getting stuck.

### Description
- Added `WoodcuttingScript` skeleton at `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.script` with lifecycle methods (`initialize`, `hasRequiredTools`, `execute`, `shutdown`) and a `WoodcuttingState` enum. 
- Wired `WoodcuttingScript` into `KSPAccountBuilderScript` so it is initialized on `run`, checked/executed inside the main scheduled loop, and shut down from `shutdown`, and simplified the script to a single scheduler loop. 
- Added GE buying helper `Buy.java` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.ge.buy` with utilities for refreshing bank state, ensuring GE slots, placing buy offers, collecting completed offers to bank, and explicit waiting using `sleepUntil(Rs2GrandExchange::hasFinishedBuyingOffers, ...)`. 
- Introduced woodcutting level utility classes `TreeLevels`, `AxeWCLevels`, and `EquipLevels` for reusable constants, and bumped the plugin version to `0.0.2` to reflect the change.

### Testing
- Attempted an automated build with `./gradlew build -PpluginList=KSPAccountBuilderPlugin -x test`, but the Gradle wrapper download failed in this environment due to a network/proxy error (`HTTP/1.1 403 Forbidden`). 
- Verified updated file contents and structure using `nl -ba` and `rg` to inspect `KSPAccountBuilderScript`, `WoodcuttingScript`, and `KSPAccountBuilderPlugin`. 
- No unit tests were added; compilation could not be validated here due to the Gradle download failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfcd3c5c8330949e566418460289)