### PR TITLE
fix: sync ksp scripts with updated woodcutting requirements

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -17,19 +17,16 @@ public class KSPAccountBuilderScript extends Script {
     @Getter
     private String status = "Idle";
 
-
     @Getter
     private String currentTask = "None";
 
     private Instant startedAt;
-
 
     private final MiningSetup miningSetup = new MiningSetup();
     private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
 
     public boolean run(KSPAccountBuilderConfig config) {
         status = "Starting";
-
         currentTask = "Initializing";
         startedAt = Instant.now();
 
@@ -52,28 +49,19 @@ public class KSPAccountBuilderScript extends Script {
 
                 // TODO: Wire mining setup into account progression workflow.
                 if (miningSetup.hasRequiredTools()) {
-
                     currentTask = "Mining";
                     miningSetup.execute();
                     return;
-
-                    miningSetup.execute();
-
                 }
 
                 // TODO: Wire woodcutting setup into account progression workflow.
                 if (woodcuttingScript.hasRequiredTools()) {
-
                     currentTask = "Woodcutting";
                     woodcuttingScript.execute();
                     return;
                 }
 
                 currentTask = "Gathering requirements";
-
-                    woodcuttingScript.execute();
-                }
-
             } catch (Exception ex) {
                 status = "Error";
                 currentTask = "Error";

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/needed/ItemReqs.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/needed/ItemReqs.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.needed;
+
+import net.runelite.api.ItemID;
+
+/**
+ * Inventory requirements checked before travelling to woodcutting areas.
+ */
+public final class ItemReqs {
+
+    private ItemReqs() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Minimum number of usable axes required in inventory/equipment.
+     */
+    public static final int MIN_AXE_COUNT = 1;
+
+    /**
+     * A usable axe must be present before travelling to chop trees.
+     */
+    public static final int[] ACCEPTED_AXE_IDS = {
+            ItemID.BRONZE_AXE,
+            ItemID.STEEL_AXE,
+            ItemID.BLACK_AXE,
+            ItemID.MITHRIL_AXE,
+            ItemID.ADAMANT_AXE,
+            ItemID.RUNE_AXE
+    };
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -2,6 +2,9 @@ package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcuttin
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.needed.ItemReqs;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 
 /**
  * Skeleton woodcutting workflow for KSPAccountBuilder.
@@ -18,8 +21,18 @@ public class WoodcuttingScript {
     }
 
     public boolean hasRequiredTools() {
-        // TODO: Validate required axe/tool availability and travel needs.
-        return false;
+        final int axeCount = getUsableAxeCount();
+        return axeCount >= ItemReqs.MIN_AXE_COUNT;
+    }
+
+    private int getUsableAxeCount() {
+        int count = 0;
+        for (int axeId : ItemReqs.ACCEPTED_AXE_IDS) {
+            if (Rs2Inventory.hasItem(axeId) || Rs2Equipment.isWearing(axeId)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public void execute() {


### PR DESCRIPTION
### Motivation
- Model pre-travel woodcutting inventory requirements explicitly so the account builder can check equipment before travelling to tree areas.
- Ensure the woodcutting workflow reports readiness only when a usable axe is present in inventory or equipped.
- Remove malformed/duplicated control flow in the KSP account builder scheduler so task transitions are deterministic.

### Description
- Add `ItemReqs` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.needed` with `MIN_AXE_COUNT` and `ACCEPTED_AXE_IDS` (common axe `ItemID`s) to represent inventory requirements.
- Update `WoodcuttingScript` to import `ItemReqs`, `Rs2Inventory`, and `Rs2Equipment`, and implement `hasRequiredTools()` which counts usable axes via `Rs2Inventory.hasItem(...)` and `Rs2Equipment.isWearing(...)` and compares to `ItemReqs.MIN_AXE_COUNT`.
- Sync `KSPAccountBuilderScript` scheduler loop to the current woodcutting flow by removing stray duplicate calls and fixing the control structure so it cleanly checks mining then woodcutting readiness and sets `currentTask` appropriately.

### Testing
- Attempted to run `./gradlew build -PpluginList=KSPAccountBuilderPlugin` to verify compilation, but the Gradle wrapper download failed in this environment due to a proxy returning `HTTP/1.1 403 Forbidden` so the build could not complete.
- No automated unit tests were executed because the build step could not finish, so compilation and runtime verification remain unconfirmed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990e1037a1c83308f6f1342756853f6)