### PR TITLE
feat(woodcutting): buy eligible axe at Grand Exchange when none available

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -17,19 +17,16 @@ public class KSPAccountBuilderScript extends Script {
     @Getter
     private String status = "Idle";
 
-
     @Getter
     private String currentTask = "None";
 
     private Instant startedAt;
-
 
     private final MiningSetup miningSetup = new MiningSetup();
     private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
 
     public boolean run(KSPAccountBuilderConfig config) {
         status = "Starting";
-
         currentTask = "Initializing";
         startedAt = Instant.now();
 
@@ -52,28 +49,19 @@ public class KSPAccountBuilderScript extends Script {
 
                 // TODO: Wire mining setup into account progression workflow.
                 if (miningSetup.hasRequiredTools()) {
-
                     currentTask = "Mining";
                     miningSetup.execute();
                     return;
-
-                    miningSetup.execute();
-
                 }
 
                 // TODO: Wire woodcutting setup into account progression workflow.
                 if (woodcuttingScript.hasRequiredTools()) {
-
                     currentTask = "Woodcutting";
                     woodcuttingScript.execute();
                     return;
                 }
 
                 currentTask = "Gathering requirements";
-
-                    woodcuttingScript.execute();
-                }
-
             } catch (Exception ex) {
                 status = "Error";
                 currentTask = "Error";

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/needed/ItemReqs.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/needed/ItemReqs.java
@@ -1,0 +1,37 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.needed;
+
+import net.runelite.api.ItemID;
+
+/**
+ * Inventory requirements checked before travelling to woodcutting areas.
+ */
+public final class ItemReqs {
+
+    private ItemReqs() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int BRONZE_AXE = ItemID.BRONZE_AXE;
+    public static final int STEEL_AXE = ItemID.STEEL_AXE;
+    public static final int BLACK_AXE = ItemID.BLACK_AXE;
+    public static final int MITHRIL_AXE = ItemID.MITHRIL_AXE;
+    public static final int ADAMANT_AXE = ItemID.ADAMANT_AXE;
+    public static final int RUNE_AXE = ItemID.RUNE_AXE;
+
+    /**
+     * Minimum number of usable axes required in inventory/equipment.
+     */
+    public static final int MIN_AXE_COUNT = 1;
+
+    /**
+     * A usable axe must be present before travelling to chop trees.
+     */
+    public static final int[] ACCEPTED_AXE_IDS = {
+            BRONZE_AXE,
+            STEEL_AXE,
+            BLACK_AXE,
+            MITHRIL_AXE,
+            ADAMANT_AXE,
+            RUNE_AXE
+    };
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -2,6 +2,20 @@ package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcuttin
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.ge.Buy;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.areas.Areas;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.levels.TreeLevels;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.needed.ItemReqs;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools.AxeWCLevels;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.tools.EquipLevels;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
 /**
  * Skeleton woodcutting workflow for KSPAccountBuilder.
@@ -9,6 +23,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 public class WoodcuttingScript {
+
+    private static final int[] AXE_IDS_DESC = {
+            ItemReqs.RUNE_AXE,
+            ItemReqs.ADAMANT_AXE,
+            ItemReqs.MITHRIL_AXE,
+            ItemReqs.BLACK_AXE,
+            ItemReqs.STEEL_AXE,
+            ItemReqs.BRONZE_AXE
+    };
 
     private WoodcuttingState state = WoodcuttingState.NOT_STARTED;
 
@@ -18,13 +41,145 @@ public class WoodcuttingScript {
     }
 
     public boolean hasRequiredTools() {
-        // TODO: Validate required axe/tool availability and travel needs.
-        return false;
+        return getUsableAxeCount() >= ItemReqs.MIN_AXE_COUNT;
+    }
+
+    private int getUsableAxeCount() {
+        int count = 0;
+        for (int axeId : ItemReqs.ACCEPTED_AXE_IDS) {
+            if (Rs2Inventory.hasItem(axeId) || Rs2Equipment.isWearing(axeId)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public void execute() {
         state = WoodcuttingState.RUNNING;
-        // TODO: Add tree selection and cutting workflow.
+
+        if (Microbot.getClient() == null || Microbot.getClient().getLocalPlayer() == null) {
+            return;
+        }
+
+        int woodcuttingLevel = Microbot.getClient().getRealSkillLevel(Skill.WOODCUTTING);
+        int attackLevel = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
+
+        if (!ensureBestAxeForCurrentLevel(woodcuttingLevel, attackLevel)) {
+            return;
+        }
+
+        WorldPoint playerLocation = Microbot.getClient().getLocalPlayer().getWorldLocation();
+        WorldArea bestArea = getBestAreaForLevel(woodcuttingLevel, playerLocation);
+        if (!bestArea.contains(playerLocation)) {
+            Rs2Walker.walkTo(getAreaCenter(bestArea), 3);
+        }
+    }
+
+    private boolean ensureBestAxeForCurrentLevel(int woodcuttingLevel, int attackLevel) {
+        int targetAxeId = getBestAxeIdByWoodcuttingLevel(woodcuttingLevel);
+        if (targetAxeId == -1) {
+            return false;
+        }
+
+        if (!hasAxe(targetAxeId)) {
+            if (!Rs2Bank.walkToBank() || !Rs2Bank.openBank()) {
+                return false;
+            }
+
+            int bestAvailableAxe = getBestAvailableAxeId(woodcuttingLevel);
+            if (bestAvailableAxe == -1) {
+                log.info("No eligible axe available. Walking to GE to buy axes.");
+                if (!Buy.buyMissingAxes()) {
+                    return false;
+                }
+                if (!Rs2Bank.walkToBank() || !Rs2Bank.openBank()) {
+                    return false;
+                }
+                bestAvailableAxe = getBestAvailableAxeId(woodcuttingLevel);
+                if (bestAvailableAxe == -1) {
+                    return false;
+                }
+            }
+
+            if (!hasAxe(bestAvailableAxe)) {
+                Rs2Bank.withdrawItem(bestAvailableAxe);
+            }
+            targetAxeId = bestAvailableAxe;
+        }
+
+        if (canEquip(targetAxeId, attackLevel)
+                && Rs2Inventory.hasItem(targetAxeId)
+                && !Rs2Equipment.isWearing(targetAxeId)) {
+            Rs2Inventory.interact(targetAxeId, "Wield");
+        }
+
+        return hasAxe(targetAxeId);
+    }
+
+    private int getBestAvailableAxeId(int woodcuttingLevel) {
+        for (int axeId : AXE_IDS_DESC) {
+            if (woodcuttingLevel >= getWoodcuttingRequirement(axeId) && (hasAxe(axeId) || Rs2Bank.hasItem(axeId))) {
+                return axeId;
+            }
+        }
+        return -1;
+    }
+
+    private boolean hasAxe(int axeId) {
+        return Rs2Inventory.hasItem(axeId) || Rs2Equipment.isWearing(axeId);
+    }
+
+    private int getBestAxeIdByWoodcuttingLevel(int woodcuttingLevel) {
+        for (int axeId : AXE_IDS_DESC) {
+            if (woodcuttingLevel >= getWoodcuttingRequirement(axeId)) {
+                return axeId;
+            }
+        }
+        return -1;
+    }
+
+    private int getWoodcuttingRequirement(int axeId) {
+        if (axeId == ItemReqs.RUNE_AXE) return AxeWCLevels.RUNE_AXE;
+        if (axeId == ItemReqs.ADAMANT_AXE) return AxeWCLevels.ADAMANT_AXE;
+        if (axeId == ItemReqs.MITHRIL_AXE) return AxeWCLevels.MITHRIL_AXE;
+        if (axeId == ItemReqs.BLACK_AXE) return AxeWCLevels.BLACK_AXE;
+        if (axeId == ItemReqs.STEEL_AXE) return AxeWCLevels.STEEL_AXE;
+        return AxeWCLevels.BRONZE_AXE;
+    }
+
+    private boolean canEquip(int axeId, int attackLevel) {
+        return attackLevel >= getAttackRequirement(axeId);
+    }
+
+    private int getAttackRequirement(int axeId) {
+        if (axeId == ItemReqs.RUNE_AXE) return EquipLevels.RUNE_AXE;
+        if (axeId == ItemReqs.ADAMANT_AXE) return EquipLevels.ADAMANT_AXE;
+        if (axeId == ItemReqs.MITHRIL_AXE) return EquipLevels.MITHRIL_AXE;
+        if (axeId == ItemReqs.BLACK_AXE) return EquipLevels.BLACK_AXE;
+        if (axeId == ItemReqs.STEEL_AXE) return EquipLevels.STEEL_AXE;
+        return EquipLevels.BRONZE_AXE;
+    }
+
+    private WorldArea getBestAreaForLevel(int woodcuttingLevel, WorldPoint playerLocation) {
+        if (woodcuttingLevel >= TreeLevels.YEW) return Areas.YEW;
+        if (woodcuttingLevel >= TreeLevels.WILLOW) return Areas.WILLOW;
+        if (woodcuttingLevel >= TreeLevels.OAK) return getClosestOakArea(playerLocation);
+        return Areas.TREES;
+    }
+
+    private WorldArea getClosestOakArea(WorldPoint playerLocation) {
+        WorldPoint varrockOakCenter = getAreaCenter(Areas.OAK_VARROCK);
+        WorldPoint draynorOakCenter = getAreaCenter(Areas.OAK_DRAYNOR);
+        int distanceToVarrock = playerLocation.distanceTo2D(varrockOakCenter);
+        int distanceToDraynor = playerLocation.distanceTo2D(draynorOakCenter);
+        return distanceToVarrock <= distanceToDraynor ? Areas.OAK_VARROCK : Areas.OAK_DRAYNOR;
+    }
+
+    private WorldPoint getAreaCenter(WorldArea area) {
+        return new WorldPoint(
+                area.getX() + (area.getWidth() / 2),
+                area.getY() + (area.getHeight() / 2),
+                area.getPlane());
     }
 
     public void shutdown() {


### PR DESCRIPTION
### Motivation

- Ensure the script always has a usable axe for the player’s current Woodcutting level before walking to a chopping area so the player does not travel without tools. 
- Provide a fallback to obtain an eligible axe via the Grand Exchange when none exist in inventory/equipment/bank.

### Description

- Added `ItemReqs` utility with axe ID constants, `MIN_AXE_COUNT`, and `ACCEPTED_AXE_IDS` to centralize axe handling. 
- Reworked `WoodcuttingScript` to select the best axe for the current Woodcutting level (`AXE_IDS_DESC`) and added helpers: `getUsableAxeCount()`, `getBestAvailableAxeId()`, `getBestAxeIdByWoodcuttingLevel()`, `getWoodcuttingRequirement()`, `canEquip()`/`getAttackRequirement()` and `hasAxe()`.
- Implemented `ensureBestAxeForCurrentLevel(...)` which checks inventory/equipment/bank, walks to bank and opens it when needed, calls `Buy.buyMissingAxes()` to run the GE buy flow if no eligible axe is found, re-checks the bank, withdraws the chosen axe, and attempts to equip it with `Rs2Inventory.interact(..., "Wield")` when Attack requirements are met.
- Kept level-aware routing (trees/oak nearest/Willow/Yew) and cleaned up minor scheduling/formatting in `KSPAccountBuilderScript` to preserve the woodcutting flow integration.

### Testing

- Attempted to run `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, but the Gradle wrapper download failed due to an external proxy returning `HTTP/1.1 403 Forbidden`, so no automated build/tests completed in this environment.
- No other automated tests were executed because the environment blocked the Gradle wrapper download.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990e1037a1c83308f6f1342756853f6)