### PR TITLE
Add combat task, task rotation, and custom break handler; update config and bump version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
@@ -23,6 +23,20 @@ public interface KSPAccountBuilderConfig extends Config {
     )
     String lootingSection = "looting";
 
+    @ConfigSection(
+            name = "Task Rotation",
+            description = "Task switching behavior",
+            position = 2
+    )
+    String taskSection = "taskRotation";
+
+    @ConfigSection(
+            name = "Break Handler",
+            description = "Custom run/break cycle behavior",
+            position = 3
+    )
+    String breakSection = "breakHandler";
+
     @ConfigItem(
             keyName = "enableAntiban",
             name = "Enable antiban",
@@ -65,5 +79,71 @@ public interface KSPAccountBuilderConfig extends Config {
     )
     default boolean enableCoinLooting() {
         return true;
+    }
+
+    @ConfigItem(
+            keyName = "taskSwitchMinutes",
+            name = "Switch task every (minutes)",
+            description = "How often to rotate between available account-builder tasks",
+            position = 0,
+            section = taskSection
+    )
+    default int taskSwitchMinutes() {
+        return 20;
+    }
+
+    @ConfigItem(
+            keyName = "enableCustomBreakHandler",
+            name = "Enable custom break handler",
+            description = "Run for random minutes then logout break for random minutes",
+            position = 0,
+            section = breakSection
+    )
+    default boolean enableCustomBreakHandler() {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "minRunMinutes",
+            name = "Run min (minutes)",
+            description = "Minimum run duration before triggering break",
+            position = 1,
+            section = breakSection
+    )
+    default int minRunMinutes() {
+        return 30;
+    }
+
+    @ConfigItem(
+            keyName = "maxRunMinutes",
+            name = "Run max (minutes)",
+            description = "Maximum run duration before triggering break",
+            position = 2,
+            section = breakSection
+    )
+    default int maxRunMinutes() {
+        return 60;
+    }
+
+    @ConfigItem(
+            keyName = "minBreakMinutes",
+            name = "Break min (minutes)",
+            description = "Minimum logout break duration",
+            position = 3,
+            section = breakSection
+    )
+    default int minBreakMinutes() {
+        return 30;
+    }
+
+    @ConfigItem(
+            keyName = "maxBreakMinutes",
+            name = "Break max (minutes)",
+            description = "Maximum logout break duration",
+            position = 4,
+            section = breakSection
+    )
+    default int maxBreakMinutes() {
+        return 60;
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -16,14 +16,14 @@ import java.awt.AWTException;
         description = "KSP account progression plugin scaffold.",
         tags = {"ksp", "account", "builder"},
         authors = {"KSP"},
-        version = KSPAccountBuilderPlugin.version,
+        version = KSPAccountBuilderPlugin.VERSION,
         minClientVersion = "2.0.13",
         enabledByDefault = PluginConstants.DEFAULT_ENABLED,
         isExternal = PluginConstants.IS_EXTERNAL
 )
 @Slf4j
 public class KSPAccountBuilderPlugin extends Plugin {
-    static final String version = "0.0.31";
+    public static final String VERSION = "0.0.32";
 
     @Inject
     private KSPAccountBuilderScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -3,25 +3,40 @@ package net.runelite.client.plugins.microbot.kspaccountbuilder;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script.CombatScript;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.woodcutting.script.WoodcuttingScript;
-import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.ui.ClientUI;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class KSPAccountBuilderScript extends Script {
     private static final long LOOP_INITIAL_DELAY_MS = 0L;
     private static final long LOOP_DELAY_MS = 1000L;
+    private static final long BREAK_PREP_WINDOW_SECONDS = 45L;
 
     private static volatile String status = "Idle";
-
     private static volatile String currentTask = "None";
-
     private static volatile Instant startedAt;
+
+    private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
+    private final CombatScript combatScript = new CombatScript();
+
+    private volatile boolean startupBankingComplete;
+    private volatile BuilderTask activeTask = BuilderTask.WOODCUTTING;
+    private volatile Instant nextTaskSwitchAt;
+
+    private volatile boolean breakActive;
+    private volatile Instant nextBreakAt;
+    private volatile Instant breakEndsAt;
+    private volatile String originalTitle;
 
     public static String getStatus() {
         return status;
@@ -31,17 +46,16 @@ public class KSPAccountBuilderScript extends Script {
         return currentTask;
     }
 
-    private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
-
-    private volatile boolean startupBankingComplete;
-
     public boolean run(KSPAccountBuilderConfig config) {
         status = "Starting";
         currentTask = "Initializing";
         startedAt = Instant.now();
         startupBankingComplete = false;
+        activeTask = BuilderTask.WOODCUTTING;
+        nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
 
         woodcuttingScript.initialize();
+        initializeBreakScheduling(config);
 
         Rs2Antiban.resetAntibanSettings();
         if (config.enableAntiban()) {
@@ -52,6 +66,15 @@ public class KSPAccountBuilderScript extends Script {
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
                 if (!super.run()) {
+                    return;
+                }
+
+                handleCustomBreaks(config);
+                updateClientTitle();
+
+                if (breakActive) {
+                    status = "On break";
+                    currentTask = "Break";
                     return;
                 }
 
@@ -69,14 +92,14 @@ public class KSPAccountBuilderScript extends Script {
                     startupBankingComplete = true;
                 }
 
+                rotateTaskIfNeeded(config);
+
                 if (config.enableAntiban() && Rs2AntibanSettings.actionCooldownActive) {
                     status = "Antiban cooldown";
                     return;
                 }
 
-                currentTask = "Woodcutting";
-                woodcuttingScript.execute();
-                status = woodcuttingScript.getStatus();
+                executeActiveTask();
 
                 if (config.enableAntiban()) {
                     Rs2Antiban.actionCooldown();
@@ -92,6 +115,28 @@ public class KSPAccountBuilderScript extends Script {
         return true;
     }
 
+    private void executeActiveTask() {
+        if (activeTask == BuilderTask.COMBAT) {
+            currentTask = "Combat";
+            combatScript.execute();
+            status = combatScript.getStatus();
+            return;
+        }
+
+        currentTask = "Woodcutting";
+        woodcuttingScript.execute();
+        status = woodcuttingScript.getStatus();
+    }
+
+    private void rotateTaskIfNeeded(KSPAccountBuilderConfig config) {
+        if (nextTaskSwitchAt == null || Instant.now().isBefore(nextTaskSwitchAt)) {
+            return;
+        }
+
+        activeTask = (activeTask == BuilderTask.WOODCUTTING) ? BuilderTask.COMBAT : BuilderTask.WOODCUTTING;
+        nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
+    }
+
     private boolean prepareForTaskStart() {
         status = "Banking before task";
 
@@ -104,6 +149,108 @@ public class KSPAccountBuilderScript extends Script {
         Rs2Bank.depositEquipment();
         status = "Ready (bank open)";
         return true;
+    }
+
+    private void initializeBreakScheduling(KSPAccountBuilderConfig config) {
+        breakActive = false;
+        breakEndsAt = null;
+        originalTitle = safeGetTitle();
+
+        if (!config.enableCustomBreakHandler()) {
+            nextBreakAt = null;
+            return;
+        }
+
+        nextBreakAt = Instant.now().plus(Duration.ofMinutes(randomBetween(config.minRunMinutes(), config.maxRunMinutes())));
+    }
+
+    private void handleCustomBreaks(KSPAccountBuilderConfig config) {
+        if (!config.enableCustomBreakHandler()) {
+            breakActive = false;
+            breakEndsAt = null;
+            return;
+        }
+
+        Instant now = Instant.now();
+        if (breakActive) {
+            if (breakEndsAt != null && now.isAfter(breakEndsAt)) {
+                breakActive = false;
+                breakEndsAt = null;
+                nextBreakAt = now.plus(Duration.ofMinutes(randomBetween(config.minRunMinutes(), config.maxRunMinutes())));
+                restoreTitle();
+                return;
+            }
+
+            if (Microbot.isLoggedIn()) {
+                status = "Logging out for break";
+                Rs2Player.logout();
+            }
+            return;
+        }
+
+        if (nextBreakAt == null) {
+            nextBreakAt = now.plus(Duration.ofMinutes(randomBetween(config.minRunMinutes(), config.maxRunMinutes())));
+            return;
+        }
+
+        Duration untilBreak = Duration.between(now, nextBreakAt);
+        if (!untilBreak.isNegative() && untilBreak.getSeconds() <= BREAK_PREP_WINDOW_SECONDS) {
+            status = "Preparing for break (walking to bank)";
+            Rs2Bank.walkToBank();
+        }
+
+        if (!now.isBefore(nextBreakAt)) {
+            breakActive = true;
+            int breakMinutes = randomBetween(config.minBreakMinutes(), config.maxBreakMinutes());
+            breakEndsAt = now.plus(Duration.ofMinutes(breakMinutes));
+            status = "Starting break";
+            Rs2Player.logout();
+        }
+    }
+
+    private void updateClientTitle() {
+        if (!breakActive || breakEndsAt == null) {
+            return;
+        }
+
+        Duration remaining = Duration.between(Instant.now(), breakEndsAt);
+        if (remaining.isNegative()) {
+            remaining = Duration.ZERO;
+        }
+
+        long minutes = remaining.toMinutes();
+        long seconds = remaining.minusMinutes(minutes).getSeconds();
+        String title = "Microbot " + KSPAccountBuilderPlugin.VERSION + " | Break Duration: "
+                + String.format("%02d:%02d", minutes, seconds);
+        safeSetTitle(title);
+    }
+
+    private void restoreTitle() {
+        if (originalTitle != null) {
+            safeSetTitle(originalTitle);
+        }
+    }
+
+    private String safeGetTitle() {
+        try {
+            return ClientUI.getFrame().getTitle();
+        } catch (Exception ex) {
+            return "RuneLite";
+        }
+    }
+
+    private void safeSetTitle(String title) {
+        try {
+            ClientUI.getFrame().setTitle(title);
+        } catch (Exception ignored) {
+            // ignore UI title failures
+        }
+    }
+
+    private int randomBetween(int min, int max) {
+        int sanitizedMin = Math.max(1, Math.min(min, max));
+        int sanitizedMax = Math.max(1, Math.max(min, max));
+        return ThreadLocalRandom.current().nextInt(sanitizedMin, sanitizedMax + 1);
     }
 
     public static String getRunningTime() {
@@ -123,8 +270,17 @@ public class KSPAccountBuilderScript extends Script {
         status = "Stopped";
         currentTask = "Stopped";
         startupBankingComplete = false;
+        breakActive = false;
+        breakEndsAt = null;
+        nextBreakAt = null;
+        restoreTitle();
         woodcuttingScript.shutdown();
         Rs2Antiban.resetAntibanSettings();
         super.shutdown();
+    }
+
+    private enum BuilderTask {
+        WOODCUTTING,
+        COMBAT
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
@@ -1,0 +1,39 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.loot;
+
+import net.runelite.api.ItemID;
+
+public final class Loot {
+    private Loot() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int[] DEFAULT_LOOT = {
+            ItemID.COWHIDE,
+            ItemID.GOBLIN_MAIL,
+            ItemID.CHEFS_HAT,
+            ItemID.AIR_TALISMAN,
+            ItemID.CLUE_SCROLL_BEGINNER,
+            ItemID.EARTH_TALISMAN,
+            ItemID.GIANT_KEY,
+            ItemID.STEEL_SCIMITAR,
+            ItemID.STEEL_LONGSWORD,
+            ItemID.IRON_ARROW,
+            ItemID.STEEL_ARROW,
+            ItemID.BRONZE_ARROW,
+            ItemID.MIND_RUNE,
+            ItemID.EARTH_RUNE,
+            ItemID.BODY_RUNE,
+            ItemID.CHAOS_RUNE,
+            ItemID.NATURE_RUNE,
+            ItemID.WATER_RUNE,
+            ItemID.LAW_RUNE,
+            ItemID.COSMIC_RUNE,
+            ItemID.DEATH_RUNE,
+            ItemID.LIMPWURT_ROOT,
+            ItemID.BODY_TALISMAN,
+            ItemID.UNCUT_SAPPHIRE,
+            ItemID.UNCUT_EMERALD,
+            ItemID.UNCUT_RUBY,
+            ItemID.UNCUT_DIAMOND
+    };
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/needed/Gear.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/needed/Gear.java
@@ -1,4 +1,62 @@
 package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.needed;
 
-public class Gear {
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.gear.armour.Armour;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.gear.swords.Swords;
+
+public final class Gear {
+    private Gear() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int MIN_TROUT_REQUIRED = 5;
+
+    public static final int[] FOOD_REQUIREMENTS = {
+            ItemID.TROUT
+    };
+
+    /**
+     * Any team cape is accepted, these are the standard wilderness team capes.
+     */
+    public static final String[] TEAM_CAPE_NAME_MATCHERS = {
+            "Team-",
+            "Team cape"
+    };
+
+    public static final int[] BEST_MELEE_WEAPONS_BY_LEVEL = {
+            Swords.RUNE_SCIMITAR,
+            Swords.ADAMANT_SCIMITAR,
+            Swords.MITHRIL_SCIMITAR,
+            Swords.BLACK_SCIMITAR,
+            Swords.STEEL_SCIMITAR,
+            Swords.IRON_SCIMITAR,
+            Swords.BRONZE_SCIMITAR
+    };
+
+    public static final int[] BEST_MELEE_ARMOUR_BY_LEVEL = {
+            Armour.RUNE_FULL_HELM,
+            Armour.RUNE_PLATEBODY,
+            Armour.RUNE_PLATELEGS,
+            Armour.RUNE_KITESHIELD,
+            Armour.ADAMANT_FULL_HELM,
+            Armour.ADAMANT_PLATEBODY,
+            Armour.ADAMANT_PLATELEGS,
+            Armour.ADAMANT_KITESHIELD,
+            Armour.MITHRIL_FULL_HELM,
+            Armour.MITHRIL_PLATEBODY,
+            Armour.MITHRIL_PLATELEGS,
+            Armour.MITHRIL_KITESHIELD,
+            Armour.BLACK_FULL_HELM,
+            Armour.BLACK_PLATEBODY,
+            Armour.BLACK_PLATELEGS,
+            Armour.BLACK_KITESHIELD,
+            Armour.IRON_FULL_HELM,
+            Armour.IRON_PLATEBODY,
+            Armour.IRON_PLATELEGS,
+            Armour.IRON_KITESHIELD,
+            Armour.BRONZE_FULL_HELM,
+            Armour.BRONZE_PLATEBODY,
+            Armour.BRONZE_PLATELEGS,
+            Armour.BRONZE_KITESHIELD
+    };
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -1,4 +1,282 @@
 package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldArea;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.areas.MobArea;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.needed.Gear;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+/**
+ * Combat progression planner for KSP Account Builder.
+ */
+@Slf4j
+@Getter
 public class CombatScript {
+    private static final int BUY_WAIT_TIMEOUT_MS = 20_000;
+    private String status = "Idle";
+
+    public CombatTrainingTarget resolveTrainingTarget() {
+        int attack = getLevel(Skill.ATTACK);
+        int strength = getLevel(Skill.STRENGTH);
+        int defence = getLevel(Skill.DEFENCE);
+
+        if (attack < 5 && strength < 5 && defence < 5) {
+            return CombatTrainingTarget.GOBLINS;
+        }
+
+        if (attack < 20 && strength < 20 && defence < 20) {
+            return CombatTrainingTarget.COWS;
+        }
+
+        if (attack < 30 && strength < 30 && defence < 30) {
+            return CombatTrainingTarget.AL_KHARID_GUARDS;
+        }
+
+        return CombatTrainingTarget.COMBAT_COMPLETE;
+    }
+
+    public void execute() {
+        if (!prepareCombatSuppliesAndUpgrades()) {
+            return;
+        }
+
+        CombatTrainingTarget target = resolveTrainingTarget();
+        status = target.getStatusText();
+    }
+
+    public boolean prepareCombatSuppliesAndUpgrades() {
+        List<String> neededPurchases = new ArrayList<>();
+
+        String bestWeapon = getBestWeaponForCurrentAttackLevel();
+        if (!hasItemAnywhere(bestWeapon)) {
+            neededPurchases.add(bestWeapon);
+        }
+
+        for (String armourPiece : getBestArmourForCurrentDefenceLevel()) {
+            if (!hasItemAnywhere(armourPiece)) {
+                neededPurchases.add(armourPiece);
+            }
+        }
+
+        if (!hasAnyTeamCape()) {
+            neededPurchases.add("Team-1 cape");
+        }
+
+        int troutCount = countItemAnywhere("Trout");
+        if (troutCount < Gear.MIN_TROUT_REQUIRED) {
+            neededPurchases.add("Trout");
+        }
+
+        if (neededPurchases.isEmpty()) {
+            status = "Combat supplies ready";
+            return true;
+        }
+
+        status = "Buying missing combat items";
+        return buyFromGrandExchange(neededPurchases);
+    }
+
+    public boolean shouldBuyMoreTrout(int troutInBank) {
+        return troutInBank < Gear.MIN_TROUT_REQUIRED;
+    }
+
+    public boolean shouldLootCowhide(CombatTrainingTarget target) {
+        return target == CombatTrainingTarget.COWS;
+    }
+
+    private int getLevel(Skill skill) {
+        if (Microbot.getClient() == null) {
+            return 1;
+        }
+
+        return Microbot.getClient().getRealSkillLevel(skill);
+    }
+
+    private String getBestWeaponForCurrentAttackLevel() {
+        int attackLevel = getLevel(Skill.ATTACK);
+
+        if (attackLevel >= 20) return "Mithril scimitar";
+        if (attackLevel >= 10) return "Black scimitar";
+        if (attackLevel >= 5) return "Steel scimitar";
+        return "Iron scimitar";
+    }
+
+    private List<String> getBestArmourForCurrentDefenceLevel() {
+        int defenceLevel = getLevel(Skill.DEFENCE);
+
+        if (defenceLevel >= 20) {
+            return List.of("Mithril full helm", "Mithril platebody", "Mithril platelegs", "Mithril kiteshield");
+        }
+
+        if (defenceLevel >= 10) {
+            return List.of("Black full helm", "Black platebody", "Black platelegs", "Black kiteshield");
+        }
+
+        return List.of("Iron full helm", "Iron platebody", "Iron platelegs", "Iron kiteshield");
+    }
+
+    private boolean hasAnyTeamCape() {
+        if (Rs2Equipment.isWearing("Team-")) {
+            return true;
+        }
+
+        if (Rs2Inventory.items().anyMatch(item -> item != null
+                && item.getName() != null
+                && isTeamCapeName(item.getName()))) {
+            return true;
+        }
+
+        return Rs2Bank.bankItems().stream().anyMatch(item -> item.getName() != null && isTeamCapeName(item.getName()));
+    }
+
+    private boolean isTeamCapeName(String name) {
+        String lower = name.toLowerCase();
+        return lower.contains("team-") || lower.contains("team cape");
+    }
+
+    private boolean hasItemAnywhere(String name) {
+        return Rs2Inventory.hasItem(name, true)
+                || Rs2Equipment.isWearing(name)
+                || countBankItem(name) > 0;
+    }
+
+    private int countItemAnywhere(String name) {
+        int inventoryCount = (int) Rs2Inventory.items()
+                .filter(item -> item != null && item.getName() != null && item.getName().equalsIgnoreCase(name))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
+        return inventoryCount + countBankItem(name);
+    }
+
+    private int countBankItem(String itemName) {
+        return Rs2Bank.bankItems().stream()
+                .filter(item -> item.getName() != null && item.getName().equalsIgnoreCase(itemName))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
+    }
+
+    private boolean buyFromGrandExchange(List<String> purchases) {
+        if (!refreshBankCache()) {
+            return false;
+        }
+
+        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
+            return false;
+        }
+
+        sleepUntil(Rs2GrandExchange::isOpen, 7_000);
+        if (!Rs2GrandExchange.isOpen()) {
+            return false;
+        }
+
+        for (String itemName : purchases) {
+            if (hasItemAnywhere(itemName)) {
+                continue;
+            }
+
+            int quantity = "Trout".equalsIgnoreCase(itemName) ? Gear.MIN_TROUT_REQUIRED : 1;
+            if (!buySingleItem(itemName, quantity)) {
+                log.warn("CombatScript: failed buying {}", itemName);
+            }
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        Rs2GrandExchange.closeExchange();
+        return true;
+    }
+
+    private boolean buySingleItem(String itemName, int quantity) {
+        if (!ensureExchangeSlotAvailable()) {
+            return false;
+        }
+
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(GrandExchangeAction.BUY)
+                .itemName(itemName)
+                .quantity(quantity)
+                .percent(8)
+                .closeAfterCompletion(false)
+                .build();
+
+        if (!Rs2GrandExchange.processOffer(request)) {
+            return false;
+        }
+
+        sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || hasItemAnywhere(itemName), BUY_WAIT_TIMEOUT_MS);
+        Rs2GrandExchange.collectAllToBank();
+        return hasItemAnywhere(itemName);
+    }
+
+    private boolean refreshBankCache() {
+        if (Rs2Bank.isOpen()) {
+            return true;
+        }
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5_000);
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 3_000);
+        return true;
+    }
+
+    private boolean ensureExchangeSlotAvailable() {
+        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
+            return true;
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> Rs2GrandExchange.getAvailableSlotsCount() > 0, 5_000);
+        return Rs2GrandExchange.getAvailableSlotsCount() > 0;
+    }
+
+    @Getter
+    public enum CombatTrainingTarget {
+        GOBLINS(
+                "Walk to goblins and fight goblins",
+                MobArea.GOBLINS,
+                new String[]{"Goblin"}
+        ),
+        COWS(
+                "Walk to cows and train on cows + cow calves",
+                MobArea.COWS,
+                new String[]{"Cow", "Cow calf"}
+        ),
+        AL_KHARID_GUARDS(
+                "Walk to Al Kharid guards and train",
+                MobArea.AL_KHARID_GUARDS,
+                new String[]{"Al-Kharid warrior", "Al-Kharid guard"}
+        ),
+        COMBAT_COMPLETE(
+                "Attack/Strength/Defence reached level 30",
+                null,
+                new String[0]
+        );
+
+        private final String statusText;
+        private final WorldArea area;
+        private final String[] npcs;
+
+        CombatTrainingTarget(String statusText, WorldArea area, String[] npcs) {
+            this.statusText = statusText;
+            this.area = area;
+            this.npcs = npcs;
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Introduce combat progression to the account builder and allow the plugin to alternate between tasks automatically. 
- Provide configurable run/break cycles so the bot can log out for randomized breaks and update the client title with break countdowns. 
- Surface new behavior toggles and parameters in `KSPAccountBuilderConfig` for task rotation and break handling. 

### Description
- Extended `KSPAccountBuilderConfig` with two new `@ConfigSection`s: `Task Rotation` and `Break Handler`, plus config items `taskSwitchMinutes`, `enableCustomBreakHandler`, `minRunMinutes`, `maxRunMinutes`, `minBreakMinutes`, and `maxBreakMinutes`. 
- Bumped plugin version constant from `version` to public `VERSION` and updated value to `"0.0.32"` in `KSPAccountBuilderPlugin`. 
- Implemented task rotation and break scheduling in `KSPAccountBuilderScript`, including a `BuilderTask` enum, logic to switch between `WOODCUTTING` and `COMBAT`, startup banking flow, and periodic UI title updates showing remaining break time via `ClientUI`. 
- Added a `CombatScript` that resolves training targets by combat stats, prepares combat supplies, purchases missing items from the Grand Exchange, and exposes helper methods for equipment/inventory/bank checks. 
- Added support utilities `Loot` and `Gear` to enumerate default combat loot and gear requirements. 
- Implemented safe UI title getters/setters, randomized timers with `randomBetween`, break preparation (walking to bank), and logout/restore behavior during breaks. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f5c23d6c483309127c89999625053)