### PR TITLE
fix(kspaccountbuilder): prevent duplicate woodcutting tree interactions

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -23,7 +23,7 @@ import java.awt.AWTException;
 )
 @Slf4j
 public class KSPAccountBuilderPlugin extends Plugin {
-    public static final String VERSION = "0.0.32";
+    public static final String VERSION = "0.0.33";
 
     @Inject
     private KSPAccountBuilderScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -72,6 +72,11 @@ public class WoodcuttingScript {
             return;
         }
 
+        if (Rs2Player.isMoving() || Rs2Player.isInteracting() || Rs2Player.isAnimating()) {
+            status = "Waiting for current action";
+            return;
+        }
+
         var tree = Rs2GameObject.findObject(java.util.Arrays.stream(target.getTreeIds()).boxed().toArray(Integer[]::new));
         if (tree == null) {
             status = "Waiting for " + target.getTreeName();


### PR DESCRIPTION
### Motivation
- The woodcutting loop could re-click a tree while the player was already moving, interacting, or animating from a prior action, causing redundant interactions.
- Reduce spammy interaction attempts and make the script wait for the current action to complete before issuing the next `Chop down`.

### Description
- Added a busy-state guard in `WoodcuttingScript.execute()` to return early when `Rs2Player.isMoving()`, `Rs2Player.isInteracting()`, or `Rs2Player.isAnimating()` are true, and set status to `Waiting for current action`.
- Updated status messaging to reflect the new waiting behaviour instead of immediately retrying interactions.
- Bumped the plugin version in `KSPAccountBuilderPlugin` from `0.0.32` to `0.0.33` to reflect the fix.
- Modified files: `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java` and `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java`.

### Testing
- Attempted to build the plugin with `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, which failed with `Permission denied` for `./gradlew` in this environment.
- Retried with `bash ./gradlew build -PpluginList=KSPAccountBuilderPlugin`, which failed because the Gradle wrapper download was blocked by a network proxy (`HTTP/1.1 403 Forbidden`), so no automated build or tests completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f61ae16588330b87498ef7a06fe8f)