### PR TITLE
KSP Account Builder: randomize start task, improve combat navigation, add GE pricing and sell logic, bump version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -23,7 +23,7 @@ import java.awt.AWTException;
 )
 @Slf4j
 public class KSPAccountBuilderPlugin extends Plugin {
-    public static final String VERSION = "0.0.32";
+    public static final String VERSION = "0.0.37";
 
     @Inject
     private KSPAccountBuilderScript script;

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -51,7 +51,7 @@ public class KSPAccountBuilderScript extends Script {
         currentTask = "Initializing";
         startedAt = Instant.now();
         startupBankingComplete = false;
-        activeTask = BuilderTask.WOODCUTTING;
+        activeTask = getRandomStartingTask();
         nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
 
         woodcuttingScript.initialize();
@@ -113,6 +113,11 @@ public class KSPAccountBuilderScript extends Script {
         }, LOOP_INITIAL_DELAY_MS, LOOP_DELAY_MS, TimeUnit.MILLISECONDS);
 
         return true;
+    }
+
+
+    private BuilderTask getRandomStartingTask() {
+        return ThreadLocalRandom.current().nextBoolean() ? BuilderTask.WOODCUTTING : BuilderTask.COMBAT;
     }
 
     private void executeActiveTask() {


### PR DESCRIPTION
### Motivation
- Reduce deterministic behavior by randomizing the initial task selection to avoid predictable runs. 
- Improve combat decision making and ensure the bot travels to the correct training areas before engaging. 
- Make woodcutting Grand Exchange interactions more robust by using market prices with sane fallbacks for buy/sell decisions. 
- Bump plugin version to reflect the set of behavior and stability improvements.

### Description
- Bumped plugin `VERSION` from `0.0.32` to `0.0.37` in `KSPAccountBuilderPlugin`.
- Randomized startup task by replacing direct assignment with `getRandomStartingTask()` that uses `ThreadLocalRandom` in `KSPAccountBuilderScript` and refactored task status handling.
- In `CombatScript` added helpers `getLowestMeleeCombatLevel()`, `getLowestMeleeSkillDisplay()` and `getAreaCenter()` and changed `resolveTrainingTarget()` to focus on the lowest melee stat; added walking to the target area using `Rs2Walker` and enhanced status reporting; wrapped execution in a `try/catch` to log errors and set a retry status.
- In `WoodcuttingScript` added GE pricing constants (`MIN_BUY_PRICE_GP`, `MIN_SELL_PRICE_GP`, `BUY_PRICE_MARKUP_MULTIPLIER`, `SELL_PRICE_DISCOUNT_MULTIPLIER`), implemented `getBuyOfferPrice()` and `getSellOfferPrice()` which use `Microbot.getItemManager().getItemPrice()` with fallback values, changed buy requests to use explicit `price` instead of `percent`, and updated axe sell logic to use computed sell prices.
- Added movement/interaction safety check in woodcutting (`isMoving`, `isInteracting`, `isAnimating`) to avoid interrupting current actions before trying to chop.

### Testing
- Ran `mvn test` for the project unit tests and they completed successfully. 
- Built the plugin with `mvn -DskipTests=false package` and the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f61ae16588330b87498ef7a06fe8f)