### PR TITLE
Add Firemaking support to KSPAccountBuilder

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/levels/LogLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/levels/LogLevels.java
@@ -1,0 +1,11 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.levels;
+
+public final class LogLevels {
+    private LogLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int LOGS = 1;
+    public static final int OAK_LOGS = 15;
+    public static final int WILLOW_LOGS = 30;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/needed/Needed.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/needed/Needed.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.needed;
+
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.levels.LogLevels;
+
+public final class Needed {
+    private Needed() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TINDERBOX = ItemID.TINDERBOX;
+    public static final int TINDERBOX_COUNT = 1;
+    public static final int LOG_COUNT = 27;
+
+    public static final int LOGS = ItemID.LOGS;
+    public static final int OAK_LOGS = ItemID.OAK_LOGS;
+    public static final int WILLOW_LOGS = ItemID.WILLOW_LOGS;
+
+    public static int getBestLogsForLevel(int firemakingLevel) {
+        if (firemakingLevel >= LogLevels.WILLOW_LOGS) {
+            return WILLOW_LOGS;
+        }
+
+        if (firemakingLevel >= LogLevels.OAK_LOGS) {
+            return OAK_LOGS;
+        }
+
+        return LOGS;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -1,0 +1,128 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.script;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.TileObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.needed.Needed;
+import net.runelite.client.plugins.microbot.util.Global;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+@Slf4j
+public class FiremakingScript {
+    private static final int CAMPFIRE_SEARCH_RADIUS = 20;
+
+    private String status = "Idle";
+
+    public void initialize() {
+        status = "Initializing firemaking";
+    }
+
+    public void shutdown() {
+        status = "Firemaking stopped";
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void execute() {
+        if (!Microbot.isLoggedIn()) {
+            status = "Waiting for login";
+            return;
+        }
+
+        int bestLogId = resolveBestLogForCurrentLevel();
+
+        if (!hasRequiredSupplies(bestLogId)) {
+            withdrawRequiredSuppliesFromGrandExchangeBank(bestLogId);
+            return;
+        }
+
+        if (tendActiveForestersCampfire(bestLogId)) {
+            return;
+        }
+
+        status = "Waiting for active Forester's Campfire at Grand Exchange";
+        Rs2GrandExchange.walkToGrandExchange();
+    }
+
+    private int resolveBestLogForCurrentLevel() {
+        int firemakingLevel = Microbot.getClient().getRealSkillLevel(Skill.FIREMAKING);
+        return Needed.getBestLogsForLevel(firemakingLevel);
+    }
+
+    private boolean hasRequiredSupplies(int bestLogId) {
+        return Rs2Inventory.hasItem(Needed.TINDERBOX)
+                && Rs2Inventory.hasItem(bestLogId)
+                && Rs2Inventory.count(bestLogId) > 0;
+    }
+
+    private void withdrawRequiredSuppliesFromGrandExchangeBank(int bestLogId) {
+        status = "Walking to Grand Exchange bank";
+        if (!Rs2GrandExchange.walkToGrandExchange()) {
+            return;
+        }
+
+        status = "Opening Grand Exchange bank";
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return;
+        }
+
+        status = "Withdrawing tinderbox and best logs";
+        Rs2Bank.depositAll();
+        Global.sleep(250);
+
+        Rs2Bank.withdrawX(Needed.TINDERBOX, Needed.TINDERBOX_COUNT);
+        Global.sleepUntil(() -> Rs2Inventory.hasItem(Needed.TINDERBOX), 3_000);
+
+        Rs2Bank.withdrawX(bestLogId, Needed.LOG_COUNT);
+        Global.sleepUntil(() -> Rs2Inventory.hasItem(bestLogId), 3_000);
+
+        if (!Rs2Inventory.hasItem(Needed.TINDERBOX) || !Rs2Inventory.hasItem(bestLogId)) {
+            status = "Missing required firemaking supplies in bank";
+            log.debug("Missing required items. Tinderbox present: {}, log {} present: {}",
+                    Rs2Inventory.hasItem(Needed.TINDERBOX),
+                    bestLogId,
+                    Rs2Inventory.hasItem(bestLogId));
+            return;
+        }
+
+        Rs2Bank.closeBank();
+    }
+
+    private boolean tendActiveForestersCampfire(int bestLogId) {
+        TileObject campfire = Rs2GameObject.findReachableObject("forester", false, CAMPFIRE_SEARCH_RADIUS, Rs2Player.getWorldLocation());
+        if (campfire == null) {
+            return false;
+        }
+
+        if (Rs2Player.distanceTo(campfire.getWorldLocation()) > 4) {
+            status = "Walking to active Forester's Campfire";
+            Rs2Walker.walkTo(campfire.getWorldLocation());
+            return true;
+        }
+
+        if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
+            status = "Waiting for current action";
+            return true;
+        }
+
+        status = "Tending active Forester's Campfire";
+        boolean tended = Rs2GameObject.interact(campfire, "Tend-to")
+                || Rs2GameObject.interact(campfire, "Tend")
+                || Rs2Inventory.useItemOnObject(bestLogId, campfire.getId());
+
+        if (tended) {
+            Global.sleepUntil(() -> Rs2Player.isAnimating() || Rs2Player.isInteracting(), 2_500);
+            Global.sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isInteracting(), 8_000);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Motivation

- Add Firemaking to the account builder so the bot can tend Forester's Campfires and train Firemaking alongside existing tasks.

### Description

- Introduces a new `FiremakingScript` with logic to resolve best logs by level, withdraw supplies from the Grand Exchange bank, and tend active Forester's Campfires. 
- Adds firemaking resource classes `Needed` and `LogLevels` to centralize item IDs, counts, and level thresholds, and exposes `Needed.getBestLogsForLevel` for log selection. 
- Integrates firemaking into `KSPAccountBuilder` by adding the `firemakingScript` field and calling `initialize()` and `shutdown()`, updating `getRandomStartingTask()` to pick from all tasks, adding `FIREMAKING` to the `BuilderTask` enum, updating `executeActiveTask()` to a `switch` that includes `FIREMAKING`, and rotating tasks through the full enum in `rotateTaskIfNeeded()`. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7915c90883309db74fa8796e8c6f)