### PR TITLE
Add Firemaking skill support and enhance combat banking/withdraw logic

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -101,13 +101,81 @@ public class CombatScript {
             neededPurchases.add("Trout");
         }
 
-        if (neededPurchases.isEmpty()) {
-            status = "Combat supplies ready";
-            return true;
+        if (!neededPurchases.isEmpty()) {
+            status = "Buying missing combat items";
+            if (!buyFromGrandExchange(neededPurchases)) {
+                return false;
+            }
         }
 
-        status = "Buying missing combat items";
-        return buyFromGrandExchange(neededPurchases);
+        return withdrawNeededCombatItems();
+    }
+
+
+    private boolean withdrawNeededCombatItems() {
+        status = "Withdrawing combat setup";
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        Rs2Bank.depositAll();
+
+        String bestWeapon = getBestWeaponForCurrentAttackLevel();
+        withdrawAndEquipIfAvailable(bestWeapon);
+
+        for (String armourPiece : getBestArmourForCurrentDefenceLevel()) {
+            withdrawAndEquipIfAvailable(armourPiece);
+        }
+
+        withdrawTeamCapeIfAvailable();
+        Rs2Bank.withdrawX("Trout", Gear.MIN_TROUT_REQUIRED, true);
+
+        Rs2Bank.closeBank();
+
+        boolean hasWeapon = Rs2Equipment.isWearing(bestWeapon) || Rs2Inventory.hasItem(bestWeapon);
+        boolean hasRequiredArmour = getBestArmourForCurrentDefenceLevel().stream()
+                .allMatch(piece -> Rs2Equipment.isWearing(piece) || Rs2Inventory.hasItem(piece));
+        boolean hasFood = countInventoryItem("Trout") >= Gear.MIN_TROUT_REQUIRED;
+
+        if (!hasWeapon || !hasRequiredArmour || !hasFood) {
+            status = "Missing combat withdrawals";
+            return false;
+        }
+
+        status = "Combat supplies ready";
+        return true;
+    }
+
+    private void withdrawAndEquipIfAvailable(String itemName) {
+        if (itemName == null || itemName.isBlank()) {
+            return;
+        }
+
+        if (Rs2Equipment.isWearing(itemName) || Rs2Inventory.hasItem(itemName)) {
+            return;
+        }
+
+        if (!Rs2Bank.hasItem(itemName)) {
+            return;
+        }
+
+        Rs2Bank.withdrawAndEquip(itemName);
+    }
+
+    private void withdrawTeamCapeIfAvailable() {
+        for (String matcher : Gear.TEAM_CAPE_NAME_MATCHERS) {
+            if (Rs2Equipment.isWearing(matcher) || Rs2Inventory.hasItem(matcher)) {
+                return;
+            }
+
+            if (Rs2Bank.hasItem(matcher)) {
+                Rs2Bank.withdrawAndEquip(matcher);
+                return;
+            }
+        }
+
+        Rs2Bank.withdrawAndEquip("Team-1 cape");
     }
 
     public boolean shouldBuyMoreTrout(int troutInBank) {
@@ -200,6 +268,13 @@ public class CombatScript {
         return Rs2Inventory.hasItem(name, true)
                 || Rs2Equipment.isWearing(name)
                 || countBankItem(name) > 0;
+    }
+
+    private int countInventoryItem(String itemName) {
+        return (int) Rs2Inventory.items()
+                .filter(item -> item != null && item.getName() != null && item.getName().equalsIgnoreCase(itemName))
+                .mapToInt(Rs2ItemModel::getQuantity)
+                .sum();
     }
 
     private int countItemAnywhere(String name) {

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/levels/LogLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/levels/LogLevels.java
@@ -1,0 +1,11 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.levels;
+
+public final class LogLevels {
+    private LogLevels() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int LOGS = 1;
+    public static final int OAK_LOGS = 15;
+    public static final int WILLOW_LOGS = 30;
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/needed/Needed.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/needed/Needed.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.needed;
+
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.levels.LogLevels;
+
+public final class Needed {
+    private Needed() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int TINDERBOX = ItemID.TINDERBOX;
+    public static final int TINDERBOX_COUNT = 1;
+    public static final int LOG_COUNT = 27;
+
+    public static final int LOGS = ItemID.LOGS;
+    public static final int OAK_LOGS = ItemID.OAK_LOGS;
+    public static final int WILLOW_LOGS = ItemID.WILLOW_LOGS;
+
+    public static int getBestLogsForLevel(int firemakingLevel) {
+        if (firemakingLevel >= LogLevels.WILLOW_LOGS) {
+            return WILLOW_LOGS;
+        }
+
+        if (firemakingLevel >= LogLevels.OAK_LOGS) {
+            return OAK_LOGS;
+        }
+
+        return LOGS;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -1,0 +1,128 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.script;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Skill;
+import net.runelite.api.TileObject;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.needed.Needed;
+import net.runelite.client.plugins.microbot.util.Global;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+@Slf4j
+public class FiremakingScript {
+    private static final int CAMPFIRE_SEARCH_RADIUS = 20;
+
+    private String status = "Idle";
+
+    public void initialize() {
+        status = "Initializing firemaking";
+    }
+
+    public void shutdown() {
+        status = "Firemaking stopped";
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void execute() {
+        if (!Microbot.isLoggedIn()) {
+            status = "Waiting for login";
+            return;
+        }
+
+        int bestLogId = resolveBestLogForCurrentLevel();
+
+        if (!hasRequiredSupplies(bestLogId)) {
+            withdrawRequiredSuppliesFromGrandExchangeBank(bestLogId);
+            return;
+        }
+
+        if (tendActiveForestersCampfire(bestLogId)) {
+            return;
+        }
+
+        status = "Waiting for active Forester's Campfire at Grand Exchange";
+        Rs2GrandExchange.walkToGrandExchange();
+    }
+
+    private int resolveBestLogForCurrentLevel() {
+        int firemakingLevel = Microbot.getClient().getRealSkillLevel(Skill.FIREMAKING);
+        return Needed.getBestLogsForLevel(firemakingLevel);
+    }
+
+    private boolean hasRequiredSupplies(int bestLogId) {
+        return Rs2Inventory.hasItem(Needed.TINDERBOX)
+                && Rs2Inventory.hasItem(bestLogId)
+                && Rs2Inventory.count(bestLogId) > 0;
+    }
+
+    private void withdrawRequiredSuppliesFromGrandExchangeBank(int bestLogId) {
+        status = "Walking to Grand Exchange bank";
+        if (!Rs2GrandExchange.walkToGrandExchange()) {
+            return;
+        }
+
+        status = "Opening Grand Exchange bank";
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return;
+        }
+
+        status = "Withdrawing tinderbox and best logs";
+        Rs2Bank.depositAll();
+        Global.sleep(250);
+
+        Rs2Bank.withdrawX(Needed.TINDERBOX, Needed.TINDERBOX_COUNT);
+        Global.sleepUntil(() -> Rs2Inventory.hasItem(Needed.TINDERBOX), 3_000);
+
+        Rs2Bank.withdrawX(bestLogId, Needed.LOG_COUNT);
+        Global.sleepUntil(() -> Rs2Inventory.hasItem(bestLogId), 3_000);
+
+        if (!Rs2Inventory.hasItem(Needed.TINDERBOX) || !Rs2Inventory.hasItem(bestLogId)) {
+            status = "Missing required firemaking supplies in bank";
+            log.debug("Missing required items. Tinderbox present: {}, log {} present: {}",
+                    Rs2Inventory.hasItem(Needed.TINDERBOX),
+                    bestLogId,
+                    Rs2Inventory.hasItem(bestLogId));
+            return;
+        }
+
+        Rs2Bank.closeBank();
+    }
+
+    private boolean tendActiveForestersCampfire(int bestLogId) {
+        TileObject campfire = Rs2GameObject.findReachableObject("forester", false, CAMPFIRE_SEARCH_RADIUS, Rs2Player.getWorldLocation());
+        if (campfire == null) {
+            return false;
+        }
+
+        if (Rs2Player.distanceTo(campfire.getWorldLocation()) > 4) {
+            status = "Walking to active Forester's Campfire";
+            Rs2Walker.walkTo(campfire.getWorldLocation());
+            return true;
+        }
+
+        if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
+            status = "Waiting for current action";
+            return true;
+        }
+
+        status = "Tending active Forester's Campfire";
+        boolean tended = Rs2GameObject.interact(campfire, "Tend-to")
+                || Rs2GameObject.interact(campfire, "Tend")
+                || Rs2Inventory.useItemOnObject(bestLogId, campfire.getId());
+
+        if (tended) {
+            Global.sleepUntil(() -> Rs2Player.isAnimating() || Rs2Player.isInteracting(), 2_500);
+            Global.sleepUntil(() -> !Rs2Player.isAnimating() && !Rs2Player.isInteracting(), 8_000);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add automated Firemaking support so the account builder can train Firemaking alongside existing skills. 
- Improve combat preparation so the script reliably acquires and equips required gear from bank or the Grand Exchange and better tracks inventory counts.

### Description
- Introduce a new `FiremakingScript` with supporting classes `Needed` and `LogLevels` to select logs by level and handle withdrawing tinderbox and logs. 
- Integrate firemaking into `KSPAccountBuilderScript` by initializing/shutting down the `FiremakingScript`, adding `BuilderTask.FIREMAKING`, updating `getRandomStartingTask`, rotating tasks generically, and switching task execution via a `switch` in `executeActiveTask`. 
- Refactor `CombatScript` to separate buying vs withdrawing flows by adding `withdrawNeededCombatItems`, `withdrawAndEquipIfAvailable`, `withdrawTeamCapeIfAvailable`, and `countInventoryItem`, and adjust `prepareCombatSuppliesAndUpgrades` to attempt GE purchases only when necessary. 
- Add inventory/bank counting improvements and tighter checks to ensure required combat items and food are present before marking supplies ready. 

### Testing
- Performed a full project build using `mvn -DskipTests=false package` and the build completed successfully. 
- Ran existing automated unit/integration tests (if present in the repository) as part of the build and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7915c90883309db74fa8796e8c6f)