### PR TITLE
Improve woodcutting GE handling, task supply checks, and antiban behavior; bump version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -24,7 +24,7 @@ import java.awt.AWTException;
 @Slf4j
 public class KSPAccountBuilderPlugin extends Plugin {
 
-    public static final String VERSION = "0.0.47";
+    public static final String VERSION = "0.0.52";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -105,7 +105,7 @@ public class KSPAccountBuilderScript extends Script {
 
                 rotateTaskIfNeeded(config);
 
-                if (config.enableAntiban() && activeTask != BuilderTask.FIREMAKING && Rs2AntibanSettings.actionCooldownActive) {
+                if (config.enableAntiban() && activeTask == BuilderTask.WOODCUTTING && Rs2AntibanSettings.actionCooldownActive) {
                     status = "Antiban cooldown";
                     return;
                 }
@@ -113,7 +113,7 @@ public class KSPAccountBuilderScript extends Script {
                 executeActiveTask();
 
                 if (config.enableAntiban()) {
-                    if (activeTask == BuilderTask.FIREMAKING) {
+                    if (activeTask != BuilderTask.WOODCUTTING) {
                         Rs2AntibanSettings.actionCooldownActive = false;
                     } else {
                         applyAntibanCycle();
@@ -231,6 +231,11 @@ public class KSPAccountBuilderScript extends Script {
     }
 
     private boolean prepareForTaskStart() {
+        if (hasRequiredSuppliesForActiveTask()) {
+            status = "Ready (inventory already prepared)";
+            return true;
+        }
+
         status = "Banking before task";
 
         if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
@@ -242,6 +247,18 @@ public class KSPAccountBuilderScript extends Script {
         Rs2Bank.depositEquipment();
         status = "Ready (bank open)";
         return true;
+    }
+
+    private boolean hasRequiredSuppliesForActiveTask() {
+        switch (activeTask) {
+            case COMBAT:
+                return combatScript.hasCombatSetupReady();
+            case FIREMAKING:
+                return firemakingScript.hasRequiredSuppliesInInventory();
+            case WOODCUTTING:
+            default:
+                return woodcuttingScript.hasRequiredTools();
+        }
     }
 
     private void initializeBreakScheduling(KSPAccountBuilderConfig config) {

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -141,7 +141,7 @@ public class CombatScript {
         return withdrawNeededCombatItems();
     }
 
-    private boolean hasCombatSetupReady() {
+    public boolean hasCombatSetupReady() {
         String bestWeapon = getBestWeaponForCurrentAttackLevel();
         boolean hasWeapon = Rs2Equipment.isWearing(bestWeapon) || Rs2Inventory.hasItem(bestWeapon);
         boolean hasRequiredArmour = getBestArmourForCurrentDefenceLevel().stream()

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -167,6 +167,11 @@ public class FiremakingScript {
         return true;
     }
 
+    public boolean hasRequiredSuppliesInInventory() {
+        int bestLogId = resolveBestLogForCurrentLevel();
+        return hasRequiredSupplies(bestLogId);
+    }
+
     private boolean hasRequiredSupplies(int bestLogId) {
         return Rs2Inventory.hasItem(Needed.TINDERBOX)
                 && Rs2Inventory.hasItem(bestLogId)

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -25,7 +25,8 @@ import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 public class WoodcuttingScript {
     private static final String CHOP_ACTION = "Chop down";
     private static final int TREE_AREA_RADIUS = 10;
-    private static final int BUY_WAIT_TIMEOUT_MS = 20_000;
+    private static final int BUY_WAIT_TIMEOUT_MS = 45_000;
+    private static final int BUY_OFFER_RETRY_COUNT = 3;
     private static final int MIN_BUY_PRICE_GP = 50;
     private static final int MIN_SELL_PRICE_GP = 25;
     private static final double BUY_PRICE_MARKUP_MULTIPLIER = 1.20;
@@ -34,12 +35,12 @@ public class WoodcuttingScript {
     private String status = "Idle";
 
     private static final Axe[] AXE_PRIORITY = new Axe[]{
-            new Axe("Rune axe", ItemReqs.RUNE_AXE, AxeWCLevels.RUNE_AXE, EquipLevels.RUNE_AXE),
-            new Axe("Adamant axe", ItemReqs.ADAMANT_AXE, AxeWCLevels.ADAMANT_AXE, EquipLevels.ADAMANT_AXE),
-            new Axe("Mithril axe", ItemReqs.MITHRIL_AXE, AxeWCLevels.MITHRIL_AXE, EquipLevels.MITHRIL_AXE),
-            new Axe("Black axe", ItemReqs.BLACK_AXE, AxeWCLevels.BLACK_AXE, EquipLevels.BLACK_AXE),
-            new Axe("Steel axe", ItemReqs.STEEL_AXE, AxeWCLevels.STEEL_AXE, EquipLevels.STEEL_AXE),
-            new Axe("Bronze axe", ItemReqs.BRONZE_AXE, AxeWCLevels.BRONZE_AXE, EquipLevels.BRONZE_AXE)
+            new Axe("Rune axe", ItemReqs.RUNE_AXE, AxeWCLevels.RUNE_AXE, EquipLevels.RUNE_AXE, 20_000),
+            new Axe("Adamant axe", ItemReqs.ADAMANT_AXE, AxeWCLevels.ADAMANT_AXE, EquipLevels.ADAMANT_AXE, 5_000),
+            new Axe("Mithril axe", ItemReqs.MITHRIL_AXE, AxeWCLevels.MITHRIL_AXE, EquipLevels.MITHRIL_AXE, 2_000),
+            new Axe("Black axe", ItemReqs.BLACK_AXE, AxeWCLevels.BLACK_AXE, EquipLevels.BLACK_AXE, 1_000),
+            new Axe("Steel axe", ItemReqs.STEEL_AXE, AxeWCLevels.STEEL_AXE, EquipLevels.STEEL_AXE, 500),
+            new Axe("Bronze axe", ItemReqs.BRONZE_AXE, AxeWCLevels.BRONZE_AXE, EquipLevels.BRONZE_AXE, MIN_BUY_PRICE_GP)
     };
 
     public void initialize() {
@@ -215,61 +216,75 @@ public class WoodcuttingScript {
             return false;
         }
 
-        try {
-            Global.sleepUntil(Rs2GrandExchange::isOpen, 7_000);
-            if (!Rs2GrandExchange.isOpen()) {
-                return false;
-            }
+        Global.sleepUntil(Rs2GrandExchange::isOpen, 7_000);
+        if (!Rs2GrandExchange.isOpen()) {
+            return false;
+        }
 
-            if (!ensureExchangeSlotAvailable()) {
-                log.debug("No GE slots available for buying {}", axe.getName());
-                return false;
-            }
+        if (!ensureExchangeSlotAvailable()) {
+            log.debug("No GE slots available for buying {}", axe.getName());
+            return false;
+        }
 
-            sellLowerTierAxesAtGrandExchange(axe);
+        sellLowerTierAxesAtGrandExchange(axe);
 
-            if (!ensureExchangeSlotAvailable()) {
-                log.debug("No GE slots available after selling lower tier axes while buying {}", axe.getName());
-                return false;
-            }
+        if (!ensureExchangeSlotAvailable()) {
+            log.debug("No GE slots available after selling lower tier axes while buying {}", axe.getName());
+            return false;
+        }
 
-            int buyPrice = getBuyOfferPrice(axe);
+        int buyPrice = getBuyOfferPrice(axe);
 
-            GrandExchangeRequest request = GrandExchangeRequest.builder()
-                    .action(GrandExchangeAction.BUY)
-                    .itemName(axe.getName())
-                    .quantity(1)
-                    .price(buyPrice)
-                    .closeAfterCompletion(false)
-                    .build();
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(GrandExchangeAction.BUY)
+                .itemName(axe.getName())
+                .quantity(1)
+                .price(buyPrice)
+                .closeAfterCompletion(false)
+                .build();
 
-            if (!Rs2GrandExchange.processOffer(request)) {
-                return false;
-            }
+        if (!placeBuyOffer(request, axe)) {
+            return false;
+        }
 
-            boolean boughtAxe = Global.sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || Rs2Inventory.hasItem(axe.getItemId()), BUY_WAIT_TIMEOUT_MS);
-            if (!boughtAxe) {
-                Rs2GrandExchange.abortAllOffers(true);
-            }
+        boolean boughtAxe = Global.sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || Rs2Inventory.hasItem(axe.getItemId()), BUY_WAIT_TIMEOUT_MS);
+        if (!boughtAxe) {
+            Rs2GrandExchange.abortAllOffers(true);
+        }
 
-            Rs2GrandExchange.collectAllToBank();
-            if (Rs2Inventory.hasItem(axe.getItemId())) {
+        Rs2GrandExchange.collectAllToBank();
+        if (Rs2Inventory.hasItem(axe.getItemId())) {
+            return true;
+        }
+
+        // Fallback verification: bank cache can be stale while GE is open, so check by opening bank.
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        boolean hasAxeInBank = Rs2Bank.hasItem(axe.getItemId());
+        Rs2Bank.closeBank();
+        return hasAxeInBank;
+    }
+
+    private boolean placeBuyOffer(GrandExchangeRequest request, Axe axe) {
+        for (int attempt = 1; attempt <= BUY_OFFER_RETRY_COUNT; attempt++) {
+            if (Rs2GrandExchange.processOffer(request)) {
                 return true;
             }
 
-            // Fallback verification: bank cache can be stale while GE is open, so check by opening bank.
-            if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
-                return false;
-            }
+            log.debug("Failed to create buy offer for {} on attempt {}/{}", axe.getName(), attempt, BUY_OFFER_RETRY_COUNT);
+            Global.sleep(600, 900);
 
-            boolean hasAxeInBank = Rs2Bank.hasItem(axe.getItemId());
-            Rs2Bank.closeBank();
-            return hasAxeInBank;
-        } finally {
-            if (Rs2GrandExchange.isOpen()) {
-                Rs2GrandExchange.closeExchange();
+            if (!Rs2GrandExchange.isOpen()) {
+                if (!Rs2GrandExchange.openExchange()) {
+                    continue;
+                }
+                Global.sleepUntil(Rs2GrandExchange::isOpen, 5_000);
             }
         }
+
+        return false;
     }
 
     private void sellLowerTierAxesAtGrandExchange(Axe bestPossibleAxe) {
@@ -308,8 +323,8 @@ public class WoodcuttingScript {
     private int getBuyOfferPrice(Axe axe) {
         int marketPrice = Microbot.getItemManager().getItemPrice(axe.getItemId());
         if (marketPrice <= 0) {
-            log.debug("Missing market price for {} ({}), falling back to min buy price", axe.getName(), axe.getItemId());
-            return MIN_BUY_PRICE_GP;
+            log.debug("Missing market price for {} ({}), falling back to tier price {}", axe.getName(), axe.getItemId(), axe.getFallbackBuyPrice());
+            return axe.getFallbackBuyPrice();
         }
 
         return Math.max(MIN_BUY_PRICE_GP, (int) Math.ceil(marketPrice * BUY_PRICE_MARKUP_MULTIPLIER));
@@ -368,12 +383,14 @@ public class WoodcuttingScript {
         private final int itemId;
         private final int woodcuttingLevel;
         private final int attackLevel;
+        private final int fallbackBuyPrice;
 
-        private Axe(String name, int itemId, int woodcuttingLevel, int attackLevel) {
+        private Axe(String name, int itemId, int woodcuttingLevel, int attackLevel, int fallbackBuyPrice) {
             this.name = name;
             this.itemId = itemId;
             this.woodcuttingLevel = woodcuttingLevel;
             this.attackLevel = attackLevel;
+            this.fallbackBuyPrice = fallbackBuyPrice;
         }
 
         private String getName() {
@@ -390,6 +407,10 @@ public class WoodcuttingScript {
 
         private int getAttackLevel() {
             return attackLevel;
+        }
+
+        private int getFallbackBuyPrice() {
+            return fallbackBuyPrice;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Make task startup more robust by avoiding unnecessary banking when inventory already contains required supplies. 
- Harden woodcutting Grand Exchange flows to handle missing market prices, retries, and proper verification of purchases. 
- Restrict antiban cooldown cycles to only run for woodcutting and expose supply-check helpers for other skills. 

### Description
- Bumped plugin `VERSION` from `0.0.47` to `0.0.52` in `KSPAccountBuilderPlugin`. 
- Changed startup banking logic in `KSPAccountBuilderScript.prepareForTaskStart()` to first check `hasRequiredSuppliesForActiveTask()` and skip banking when supplies are present, and added the helper `hasRequiredSuppliesForActiveTask()`. 
- Updated antiban conditionals so cooldowns and the `applyAntibanCycle()` only trigger for `BuilderTask.WOODCUTTING` and not other tasks. 
- Made `CombatScript.hasCombatSetupReady()` public and added `FiremakingScript.hasRequiredSuppliesInInventory()` to allow the central supply check to query each skill. 
- Reworked `WoodcuttingScript` GE and buying flow by increasing `BUY_WAIT_TIMEOUT_MS`, adding `BUY_OFFER_RETRY_COUNT`, per-axe fallback buy prices, a `placeBuyOffer()` retry loop, selling lower-tier axes before purchases, better GE/bank verification after buy, and other robustness/logging fixes. 
- Introduced per-axe fallback prices in `WoodcuttingScript.Axe` and updated AXE_PRIORITY entries to include those fallback prices. 

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fbc030af48330a3b8bf476f3dc833)