### PR TITLE
fix: prevent combat script idling inside training area

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -25,7 +25,7 @@ import java.awt.AWTException;
 public class KSPAccountBuilderPlugin extends Plugin {
 
 
-    public static final String VERSION = "0.0.54";
+    public static final String VERSION = "0.0.55";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -101,6 +101,11 @@ public class CombatScript {
                 return;
             }
 
+            if (repositionWithinTrainingArea(targetArea)) {
+                status = "Repositioning in " + target.name().replace('_', ' ').toLowerCase();
+                return;
+            }
+
             status = target.getStatusText() + " | Focus " + getLowestMeleeSkillDisplay()
                     + " (A/S/D: " + getLevel(Skill.ATTACK) + "/" + getLevel(Skill.STRENGTH) + "/" + getLevel(Skill.DEFENCE) + ")";
         } catch (Exception ex) {
@@ -355,6 +360,26 @@ public class CombatScript {
         }
 
         sleepUntil(() -> Rs2Player.isInteracting() || Rs2Player.isAnimating(), 3_000);
+        return true;
+    }
+
+    private boolean repositionWithinTrainingArea(WorldArea targetArea) {
+        if (targetArea == null || Rs2Player.isMoving()) {
+            return false;
+        }
+
+        WorldPoint playerLocation = Rs2Player.getWorldLocation();
+        WorldPoint areaCenter = getAreaCenter(targetArea);
+        if (playerLocation == null || areaCenter == null) {
+            return false;
+        }
+
+        if (!targetArea.contains(playerLocation) || playerLocation.distanceTo(areaCenter) <= 5) {
+            return false;
+        }
+
+        Rs2Walker.walkTo(areaCenter);
+        sleepUntil(Rs2Player::isMoving, 2_000);
         return true;
     }
 


### PR DESCRIPTION
### Motivation
- Combat script could idle while already inside a training `WorldArea` when no NPC was attackable, causing wasted cycles and lack of repositioning.
- Improve reliability by nudging the player toward denser NPC spawn tiles rather than remaining on sparse edge tiles.

### Description
- Add a new helper `repositionWithinTrainingArea(WorldArea)` that walks the player toward the `WorldArea` center when inside the area but too far from the center, and waits for movement start. (`CombatScript.java`)
- Invoke `repositionWithinTrainingArea(...)` in `CombatScript.execute()` as a fallback before falling back to the status-only behavior so the script actively repositions instead of idling. (`CombatScript.java`)
- Bump plugin version constant from `0.0.54` to `0.0.55` in `KSPAccountBuilderPlugin.java` to reflect behavioral change.

### Testing
- Attempted to run `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, which failed in this environment because the Gradle wrapper download is blocked by the network proxy (`HTTP/1.1 403 Forbidden`).
- No repository-wide automated tests were completed due to the Gradle download failure, but the changes compile-time shape is limited to additions and control flow (no breaking API changes), and a local build should validate the change once Gradle can be fetched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a055d19c208330a6d1fe51a6f2a551)