### PR TITLE
fix(kspaccountbuilder): remove duplicated method blocks in scripts and bump plugin version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -26,7 +26,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.56";
+    public static final String VERSION = "0.0.57";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -17,8 +17,6 @@ import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
-import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
-import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
@@ -29,6 +27,7 @@ import net.runelite.client.plugins.microbot.util.npc.Rs2NpcModel;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
 import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -41,7 +40,6 @@ public class CombatScript {
     private static final int BUY_WAIT_TIMEOUT_MS = 20_000;
     private static final int LOOT_RADIUS = 8;
     private static final int GE_TROUT_RESTOCK_AMOUNT = 500;
-
     private static final long REPOSITION_COOLDOWN_MS = 3_500L;
 
     private boolean boneBuryEnabled = true;
@@ -51,34 +49,6 @@ public class CombatScript {
     private WorldPoint lastKillLocation;
     private long lastKillAt = 0L;
     private long lastRepositionAttemptAt = 0L;
-
-
-
-    private static final long REPOSITION_COOLDOWN_MS = 3_500L;
-
-
-
-    private static final String[] SELLABLE_BANK_ITEMS_KEEP_ONE = {
-            "Goblin mail",
-            "Chef's hat",
-            "Air talisman",
-            "Earth talisman",
-            "Cowhide",
-            "Steel longsword",
-            "Limpwurt root",
-            "Body talisman"
-    };
-
-    private boolean boneBuryEnabled = true;
-    private boolean coinLootingEnabled = true;
-    private String status = "Idle";
-
-    private boolean wasInCombatLastTick = false;
-    private WorldPoint lastKillLocation;
-    private long lastKillAt = 0L;
-    private long lastRepositionAttemptAt = 0L;
-
-
 
     public void configureLooting(boolean enableBoneBury, boolean enableCoinLooting) {
         this.boneBuryEnabled = enableBoneBury;
@@ -108,26 +78,11 @@ public class CombatScript {
             updateKillWindow(target);
 
             if (Rs2Player.isInteracting() || Rs2Player.isAnimating()) {
-
-            updateKillWindow(target);
-
-            if (Rs2Player.isInteracting() || Rs2Player.isAnimating()) {
-
-            if (Rs2Player.isInteracting() || Rs2Player.isAnimating() || Rs2Player.isMoving()) {
-
-
                 status = "Fighting in " + target.getDisplayName();
                 return;
             }
 
-
             if (lootDropsInArea(target)) {
-
-
-            if (lootDropsInArea(target)) {
-
-            if (lootDropsInArea()) {
-
                 status = "Looting drops";
                 return;
             }
@@ -142,18 +97,10 @@ public class CombatScript {
                 return;
             }
 
-
-            if (moveTowardsTargetNpc(target)) {
-                status = "Moving to target in " + target.getDisplayName();
-                return;
-            }
-
-
             if (repositionWithinTrainingArea(target.getArea())) {
                 status = "Repositioning in " + target.getDisplayName();
                 return;
             }
-
 
             status = "Waiting for targets in " + target.getDisplayName();
         } catch (Exception ex) {
@@ -166,22 +113,16 @@ public class CombatScript {
         String weapon = getBestWeaponForAttack();
         boolean hasWeapon = hasItemInInventoryOrEquipped(weapon);
         boolean hasArmour = getBestArmourForDefence().stream().allMatch(this::hasItemInInventoryOrEquipped);
-
         boolean hasAmulet = hasItemInInventoryOrEquipped("Amulet of power");
         boolean hasTeamCape = hasAnyTeamCapeInInventoryOrEquipped();
         boolean hasFood = countInventoryItem("Trout") >= Gear.MIN_TROUT_REQUIRED;
         return hasWeapon && hasArmour && hasAmulet && hasTeamCape && hasFood;
-
-        boolean hasFood = countInventoryItem("Trout") >= Gear.MIN_TROUT_REQUIRED;
-        return hasWeapon && hasArmour && hasFood;
-
     }
 
     private boolean ensureCombatLoadout() {
         if (hasCombatSetupReady()) {
             return true;
         }
-
 
         // If we already carry needed items in inventory, don't force banking.
         if (hasInventoryLoadoutWithoutFood() && countInventoryItem("Trout") >= Gear.MIN_TROUT_REQUIRED) {
@@ -239,64 +180,6 @@ public class CombatScript {
         if (!isPlayerInTargetArea(target.getArea()) || !canLootFromRecentKill(target)) {
             return false;
         }
-
-
-
-        // If we already carry needed items in inventory, don't force banking.
-        if (hasInventoryLoadoutWithoutFood() && countInventoryItem("Trout") >= Gear.MIN_TROUT_REQUIRED) {
-            return true;
-        }
-
-        if (!refreshBankCache()) {
-            status = "Unable to read bank";
-            return false;
-        }
-
-        if (!sellConfiguredBankOverflow()) {
-            return false;
-        }
-
-        if (countBankItem("Trout") < Gear.MIN_TROUT_REQUIRED) {
-            if (!buyFromGrandExchange("Trout", GE_TROUT_RESTOCK_AMOUNT)) {
-                status = "Failed buying trout";
-                return false;
-            }
-        }
-
-        List<String> upgradeItems = getRequiredUpgradeItems();
-        for (String item : upgradeItems) {
-
-            boolean alreadyOwned = "Team-1 cape".equalsIgnoreCase(item)
-                    ? hasAnyTeamCapeAnywhere()
-                    : hasItemAnywhere(item);
-            if (!alreadyOwned) {
-
-            if (!hasItemAnywhere(item)) {
-
-                if (!buyFromGrandExchange(item, 1)) {
-                    log.warn("Failed buying upgrade: {}", item);
-                }
-            }
-        }
-
-        if (!withdrawCombatSetup()) {
-            status = "Could not withdraw combat setup";
-            return false;
-        }
-
-        return hasCombatSetupReady();
-    }
-
-
-    private boolean lootDropsInArea(CombatTrainingTarget target) {
-        if (!isPlayerInTargetArea(target.getArea()) || !canLootFromRecentKill(target)) {
-
-    private boolean lootDropsInArea() {
-        if (!isPlayerInTargetArea(resolveTrainingTarget().getArea())) {
-
-            return false;
-        }
-
 
         if (boneBuryEnabled && buryBonesInInventory()) {
             return true;
@@ -453,12 +336,6 @@ public class CombatScript {
         Rs2Bank.depositAll();
         Rs2Bank.depositEquipment();
 
-
-        withdrawAndEquip(getBestWeaponForAttack());
-        for (String piece : getBestArmourForDefence()) {
-            withdrawAndEquip(piece);
-
-
         withdrawAndEquip(getBestWeaponForAttack());
         for (String piece : getBestArmourForDefence()) {
             withdrawAndEquip(piece);
@@ -499,399 +376,11 @@ public class CombatScript {
     private boolean hasAnyTeamCapeInInventoryOrEquipped() {
         for (String matcher : Gear.TEAM_CAPE_NAME_MATCHERS) {
             if (Rs2Equipment.isWearing(matcher) || Rs2Inventory.hasItem(matcher, true)) {
-
-    private boolean withdrawCombatSetup() {
-        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
-            return false;
-
-        }
-        withdrawAndEquip("Amulet of power");
-        withdrawAnyTeamCape();
-
-
-        Rs2Bank.withdrawX("Trout", Gear.MIN_TROUT_REQUIRED, true);
-
-
-        Rs2Bank.depositAll();
-        Rs2Bank.depositEquipment();
-
-        withdrawAndEquip(getBestWeaponForAttack());
-        for (String piece : getBestArmourForDefence()) {
-            withdrawAndEquip(piece);
-        }
-
-        Rs2Bank.withdrawX("Trout", Gear.MIN_TROUT_REQUIRED, true);
-
-        Rs2Bank.closeBank();
-        sleepUntil(() -> !Rs2Bank.isOpen(), 3_000);
-        return true;
-    }
-
-    private void withdrawAndEquip(String itemName) {
-        if (itemName == null || itemName.isBlank()) {
-            return;
-        }
-        if (hasItemInInventoryOrEquipped(itemName)) {
-            return;
-        }
-        if (!Rs2Bank.hasItem(itemName)) {
-            return;
-        }
-        Rs2Bank.withdrawAndEquip(itemName);
-    }
-
-
-
-    private boolean hasAnyTeamCapeAnywhere() {
-        if (hasAnyTeamCapeInInventoryOrEquipped()) {
-            return true;
-        }
-
-        return Rs2Bank.bankItems().stream()
-                .anyMatch(item -> item.getName() != null && isTeamCapeName(item.getName()));
-    }
-
-    private boolean hasAnyTeamCapeInInventoryOrEquipped() {
-        for (String matcher : Gear.TEAM_CAPE_NAME_MATCHERS) {
-            if (Rs2Equipment.isWearing(matcher) || Rs2Inventory.hasItem(matcher, true)) {
-                return true;
-
-    private boolean sellConfiguredBankOverflow() {
-        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
-            status = "Walking to GE";
-            return false;
-        }
-
-        sleepUntil(Rs2GrandExchange::isOpen, 7_000);
-        if (!Rs2GrandExchange.isOpen()) {
-            return false;
-        }
-
-        for (String itemName : SELLABLE_BANK_ITEMS_KEEP_ONE) {
-            int amountInBank = countBankItem(itemName);
-            int toSell = Math.max(0, amountInBank - 1);
-            if (toSell <= 0) {
-                continue;
-            }
-
-            if (!ensureExchangeSlotAvailable()) {
-                continue;
-
-            }
-
-            GrandExchangeRequest request = GrandExchangeRequest.builder()
-                    .action(GrandExchangeAction.SELL)
-                    .itemName(itemName)
-                    .quantity(toSell)
-                    .percent(-5)
-                    .closeAfterCompletion(false)
-                    .build();
-
-            Rs2GrandExchange.processOffer(request);
-            sleepUntil(() -> Rs2GrandExchange.hasSoldOffer() || Rs2GrandExchange.hasBoughtOffer(), BUY_WAIT_TIMEOUT_MS);
-            Rs2GrandExchange.collectAllToBank();
-        }
-
-        Rs2GrandExchange.closeExchange();
-        return true;
-    }
-
-
-    private void withdrawAnyTeamCape() {
-        if (hasAnyTeamCapeInInventoryOrEquipped()) {
-            return;
-        }
-
-        for (String matcher : Gear.TEAM_CAPE_NAME_MATCHERS) {
-            if (Rs2Bank.hasItem(matcher)) {
-                Rs2Bank.withdrawAndEquip(matcher);
-                sleepUntil(this::hasAnyTeamCapeInInventoryOrEquipped, 2_000);
-                return;
-            }
-        }
-
-        if (Rs2Bank.hasItem("Team-1 cape")) {
-            Rs2Bank.withdrawAndEquip("Team-1 cape");
-            sleepUntil(this::hasAnyTeamCapeInInventoryOrEquipped, 2_000);
-        }
-
-    private boolean buyFromGrandExchange(String itemName, int quantity) {
-        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
-            return false;
-        }
-
-        sleepUntil(Rs2GrandExchange::isOpen, 7_000);
-        if (!Rs2GrandExchange.isOpen()) {
-            return false;
-        }
-
-        if (!ensureExchangeSlotAvailable()) {
-            return false;
-        }
-
-        GrandExchangeRequest request = GrandExchangeRequest.builder()
-                .action(GrandExchangeAction.BUY)
-                .itemName(itemName)
-                .quantity(quantity)
-                .percent(8)
-                .closeAfterCompletion(false)
-                .build();
-
-        boolean offered = Rs2GrandExchange.processOffer(request);
-        if (!offered) {
-            return false;
-        }
-
-        sleepUntil(() -> hasItemAnywhere(itemName) || Rs2GrandExchange.hasBoughtOffer(), BUY_WAIT_TIMEOUT_MS);
-        Rs2GrandExchange.collectAllToBank();
-        Rs2GrandExchange.closeExchange();
-        return hasItemAnywhere(itemName);
-
-    }
-
-    private boolean refreshBankCache() {
-        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
-            return false;
-        }
-
-
-        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5_000);
-        Rs2Bank.closeBank();
-        sleepUntil(() -> !Rs2Bank.isOpen(), 3_000);
-        return true;
-
-
-        sleepUntil(() -> !Rs2Bank.bankItems().isEmpty(), 5_000);
-        Rs2Bank.closeBank();
-        sleepUntil(() -> !Rs2Bank.isOpen(), 3_000);
-        return true;
-    }
-
-    private boolean ensureExchangeSlotAvailable() {
-        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
-            return true;
-        }
-
-        Rs2GrandExchange.collectAllToBank();
-        sleepUntil(() -> Rs2GrandExchange.getAvailableSlotsCount() > 0, 5_000);
-        return Rs2GrandExchange.getAvailableSlotsCount() > 0;
-
-    }
-
-    private void setBalancedMeleeStyle() {
-        int attack = getLevel(Skill.ATTACK);
-        int strength = getLevel(Skill.STRENGTH);
-        int defence = getLevel(Skill.DEFENCE);
-
-        Skill targetSkill = Skill.ATTACK;
-        if (strength < attack && strength <= defence) {
-            targetSkill = Skill.STRENGTH;
-        } else if (defence < attack && defence <= strength) {
-            targetSkill = Skill.DEFENCE;
-
-        }
-
-        int currentStyle = Microbot.getVarbitPlayerValue(VarPlayer.ATTACK_STYLE);
-        WidgetInfo desired = getStyleWidgetForSkill(targetSkill);
-        int desiredStyle = styleIndexForSkill(targetSkill);
-
-        if (currentStyle == desiredStyle) {
-            return;
-        }
-
-        if (Rs2Tab.getCurrentTab() != InterfaceTab.COMBAT) {
-            Rs2Tab.switchToCombatOptionsTab();
-            sleepUntil(() -> Rs2Tab.getCurrentTab() == InterfaceTab.COMBAT, 2_000);
-        }
-
-
-        }
-
-        int currentStyle = Microbot.getVarbitPlayerValue(VarPlayer.ATTACK_STYLE);
-        WidgetInfo desired = getStyleWidgetForSkill(targetSkill);
-        int desiredStyle = styleIndexForSkill(targetSkill);
-
-        if (currentStyle == desiredStyle) {
-            return;
-        }
-
-        if (Rs2Tab.getCurrentTab() != InterfaceTab.COMBAT) {
-            Rs2Tab.switchToCombatOptionsTab();
-            sleepUntil(() -> Rs2Tab.getCurrentTab() == InterfaceTab.COMBAT, 2_000);
-        }
-
-
-        Rs2Combat.setAttackStyle(desired);
-    }
-
-    private WidgetInfo getStyleWidgetForSkill(Skill skill) {
-        if (skill == Skill.STRENGTH) {
-            return WidgetInfo.COMBAT_STYLE_TWO;
-        }
-        if (skill == Skill.DEFENCE) {
-            return WidgetInfo.COMBAT_STYLE_FOUR;
-        }
-        return WidgetInfo.COMBAT_STYLE_ONE;
-    }
-
-    private int styleIndexForSkill(Skill skill) {
-        if (skill == Skill.STRENGTH) {
-            return 1;
-        }
-        if (skill == Skill.DEFENCE) {
-            return 3;
-        }
-        return 0;
-    }
-
-    private CombatTrainingTarget resolveTrainingTarget() {
-
-        int lowestMelee = Math.min(getLevel(Skill.ATTACK), Math.min(getLevel(Skill.STRENGTH), getLevel(Skill.DEFENCE)));
-
-        if (lowestMelee < 5) {
-            return CombatTrainingTarget.GOBLINS;
-        }
-
-        if (lowestMelee < 10) {
-            return CombatTrainingTarget.COWS;
-        }
-
-        if (lowestMelee >= 20) {
-
-        int attack = getLevel(Skill.ATTACK);
-        int strength = getLevel(Skill.STRENGTH);
-        int defence = getLevel(Skill.DEFENCE);
-
-        if (attack < 5 && strength < 5 && defence < 5) {
-            return CombatTrainingTarget.GOBLINS;
-        }
-
-        if (attack >= 5 && strength >= 5 && defence >= 5 && attack < 10 && strength < 10 && defence < 10) {
-            return CombatTrainingTarget.COWS;
-        }
-
-        if (attack >= 20 && strength >= 20 && defence >= 20) {
-
-            return CombatTrainingTarget.AL_KHARID_GUARDS;
-        }
-
-        return CombatTrainingTarget.COWS;
-    }
-
-    private List<String> getRequiredUpgradeItems() {
-        List<String> items = new ArrayList<>();
-        items.add(getBestWeaponForAttack());
-        items.addAll(getBestArmourForDefence());
-
-        items.add("Amulet of power");
-        items.add("Team-1 cape");
-
-        return items;
-    }
-
-    private String getBestWeaponForAttack() {
-        int attack = getLevel(Skill.ATTACK);
-        if (attack >= 20) return "Mithril scimitar";
-        if (attack >= 10) return "Black scimitar";
-        if (attack >= 5) return "Steel scimitar";
-        return "Iron scimitar";
-    }
-
-    private List<String> getBestArmourForDefence() {
-        int defence = getLevel(Skill.DEFENCE);
-        if (defence >= 20) {
-            return List.of("Mithril full helm", "Mithril platebody", "Mithril platelegs", "Mithril kiteshield");
-        }
-        if (defence >= 10) {
-            return List.of("Black full helm", "Black platebody", "Black platelegs", "Black kiteshield");
-        }
-        return List.of("Iron full helm", "Iron platebody", "Iron platelegs", "Iron kiteshield");
-    }
-
-    private boolean isPlayerInTargetArea(WorldArea area) {
-        WorldPoint location = Rs2Player.getWorldLocation();
-        return area != null && location != null && area.contains(location);
-
-    }
-
-    private WorldPoint getAreaCenter(WorldArea area) {
-        return new WorldPoint(area.getX() + (area.getWidth() / 2), area.getY() + (area.getHeight() / 2), area.getPlane());
-    }
-
-    private boolean matchesAnyTarget(String npcName, String[] targetNames) {
-        String normalized = npcName.trim().toLowerCase();
-        for (String target : targetNames) {
-            String needle = target.trim().toLowerCase();
-            if (normalized.equals(needle) || normalized.contains(needle)) {
                 return true;
             }
         }
         return false;
     }
-
-    private boolean isTeamCapeName(String name) {
-        if (name == null) {
-            return false;
-        }
-        String lower = name.toLowerCase();
-        return lower.contains("team-") || lower.contains("team cape");
-    }
-
-    private boolean hasInventoryLoadoutWithoutFood() {
-        String weapon = getBestWeaponForAttack();
-        boolean hasWeapon = hasItemInInventoryOrEquipped(weapon);
-        boolean hasArmour = getBestArmourForDefence().stream().allMatch(this::hasItemInInventoryOrEquipped);
-        boolean hasAmulet = hasItemInInventoryOrEquipped("Amulet of power");
-        boolean hasTeamCape = hasAnyTeamCapeInInventoryOrEquipped();
-        return hasWeapon && hasArmour && hasAmulet && hasTeamCape;
-    }
-
-    private boolean hasItemInInventoryOrEquipped(String item) {
-        return Rs2Inventory.hasItem(item, true) || Rs2Equipment.isWearing(item);
-    }
-
-    private boolean hasItemAnywhere(String item) {
-        return hasItemInInventoryOrEquipped(item) || countBankItem(item) > 0;
-    }
-
-    private int countInventoryItem(String itemName) {
-        return (int) Rs2Inventory.items()
-                .filter(i -> i != null && i.getName() != null && i.getName().equalsIgnoreCase(itemName))
-                .mapToInt(Rs2ItemModel::getQuantity)
-                .sum();
-    }
-
-    private int countBankItem(String itemName) {
-        return Rs2Bank.bankItems().stream()
-                .filter(i -> i.getName() != null && i.getName().equalsIgnoreCase(itemName))
-                .mapToInt(Rs2ItemModel::getQuantity)
-                .sum();
-    }
-
-    private int getLevel(Skill skill) {
-        if (Microbot.getClient() == null) {
-            return 1;
-        }
-        return Microbot.getClient().getRealSkillLevel(skill);
-
-    }
-
-    private WorldPoint getAreaCenter(WorldArea area) {
-        return new WorldPoint(area.getX() + (area.getWidth() / 2), area.getY() + (area.getHeight() / 2), area.getPlane());
-    }
-
-    private boolean matchesAnyTarget(String npcName, String[] targetNames) {
-        String normalized = npcName.trim().toLowerCase();
-        for (String target : targetNames) {
-            String needle = target.trim().toLowerCase();
-            if (normalized.equals(needle) || normalized.contains(needle)) {
-
-                return true;
-            }
-        }
-        return false;
-    }
-
 
     private void withdrawAnyTeamCape() {
         if (hasAnyTeamCapeInInventoryOrEquipped()) {
@@ -912,78 +401,6 @@ public class CombatScript {
         }
     }
 
-    private boolean sellConfiguredBankOverflow() {
-        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
-            status = "Walking to GE";
-            return false;
-        }
-
-        sleepUntil(Rs2GrandExchange::isOpen, 7_000);
-        if (!Rs2GrandExchange.isOpen()) {
-            return false;
-        }
-
-        for (String itemName : SELLABLE_BANK_ITEMS_KEEP_ONE) {
-            int amountInBank = countBankItem(itemName);
-            int toSell = Math.max(0, amountInBank - 1);
-            if (toSell <= 0) {
-                continue;
-            }
-
-            if (!ensureExchangeSlotAvailable()) {
-                continue;
-            }
-
-            GrandExchangeRequest request = GrandExchangeRequest.builder()
-                    .action(GrandExchangeAction.SELL)
-                    .itemName(itemName)
-                    .quantity(toSell)
-                    .percent(-5)
-                    .closeAfterCompletion(false)
-                    .build();
-
-            Rs2GrandExchange.processOffer(request);
-            sleepUntil(() -> Rs2GrandExchange.hasSoldOffer() || Rs2GrandExchange.hasBoughtOffer(), BUY_WAIT_TIMEOUT_MS);
-            Rs2GrandExchange.collectAllToBank();
-        }
-
-        Rs2GrandExchange.closeExchange();
-        return true;
-    }
-
-    private boolean buyFromGrandExchange(String itemName, int quantity) {
-        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
-            return false;
-        }
-
-        sleepUntil(Rs2GrandExchange::isOpen, 7_000);
-        if (!Rs2GrandExchange.isOpen()) {
-            return false;
-        }
-
-        if (!ensureExchangeSlotAvailable()) {
-            return false;
-        }
-
-        GrandExchangeRequest request = GrandExchangeRequest.builder()
-                .action(GrandExchangeAction.BUY)
-                .itemName(itemName)
-                .quantity(quantity)
-                .percent(8)
-                .closeAfterCompletion(false)
-                .build();
-
-        boolean offered = Rs2GrandExchange.processOffer(request);
-        if (!offered) {
-            return false;
-        }
-
-        sleepUntil(() -> hasItemAnywhere(itemName) || Rs2GrandExchange.hasBoughtOffer(), BUY_WAIT_TIMEOUT_MS);
-        Rs2GrandExchange.collectAllToBank();
-        Rs2GrandExchange.closeExchange();
-        return hasItemAnywhere(itemName);
-    }
-
     private boolean refreshBankCache() {
         if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
             return false;
@@ -993,47 +410,6 @@ public class CombatScript {
         Rs2Bank.closeBank();
         sleepUntil(() -> !Rs2Bank.isOpen(), 3_000);
         return true;
-    }
-
-    private boolean ensureExchangeSlotAvailable() {
-        if (Rs2GrandExchange.getAvailableSlotsCount() > 0) {
-            return true;
-
-    private boolean hasInventoryLoadoutWithoutFood() {
-        String weapon = getBestWeaponForAttack();
-        boolean hasWeapon = hasItemInInventoryOrEquipped(weapon);
-        boolean hasArmour = getBestArmourForDefence().stream().allMatch(this::hasItemInInventoryOrEquipped);
-        return hasWeapon && hasArmour;
-    }
-
-    private boolean hasItemInInventoryOrEquipped(String item) {
-        return Rs2Inventory.hasItem(item, true) || Rs2Equipment.isWearing(item);
-    }
-
-    private boolean hasItemAnywhere(String item) {
-        return hasItemInInventoryOrEquipped(item) || countBankItem(item) > 0;
-    }
-
-    private int countInventoryItem(String itemName) {
-        return (int) Rs2Inventory.items()
-                .filter(i -> i != null && i.getName() != null && i.getName().equalsIgnoreCase(itemName))
-                .mapToInt(Rs2ItemModel::getQuantity)
-                .sum();
-    }
-
-    private int countBankItem(String itemName) {
-        return Rs2Bank.bankItems().stream()
-                .filter(i -> i.getName() != null && i.getName().equalsIgnoreCase(itemName))
-                .mapToInt(Rs2ItemModel::getQuantity)
-                .sum();
-    }
-
-    private int getLevel(Skill skill) {
-        if (Microbot.getClient() == null) {
-            return 1;
-
-        }
-        return Microbot.getClient().getRealSkillLevel(skill);
     }
 
     private void setBalancedMeleeStyle() {
@@ -1194,7 +570,6 @@ public class CombatScript {
             return 1;
         }
         return Microbot.getClient().getRealSkillLevel(skill);
-
     }
 
     @Getter

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -76,57 +76,7 @@ public class FiremakingScript {
 
 
     private boolean handleProductSelectionDialogue() {
-
         if (!isProductSelectionDialogueOpen()) {
-
-
-        if (!isProductSelectionDialogueOpen()) {
-
-
-
-        if (!Rs2Widget.hasWidget("Product selection") && !Rs2Widget.hasWidget("How many would you like to burn?")) {
-
-
-            return false;
-        }
-
-        status = "Confirming product selection";
-
-
-        // Handle both old/new production UIs: try clickable options first, then keyboard fallback.
-        Rs2Widget.clickWidget("All");
-        Rs2Widget.clickWidget("Continue");
-        Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
-
-        Global.sleepUntil(() -> !isProductSelectionDialogueOpen()
-                || Rs2Player.isAnimating()
-                || Rs2Player.isInteracting(), 2_500);
-        return true;
-    }
-
-    private boolean isProductSelectionDialogueOpen() {
-        for (String prompt : PRODUCT_SELECTION_PROMPTS) {
-            if (Rs2Widget.hasWidget(prompt)) {
-                return true;
-            }
-        }
-
-        return Rs2Widget.isProductionWidgetOpen();
-    }
-
-
-
-        Rs2Keyboard.keyPress(KeyEvent.VK_SPACE);
-        Global.sleepUntil(() -> !Rs2Widget.hasWidget("Product selection")
-                && !Rs2Widget.hasWidget("How many would you like to burn?"), 2_000);
-        return true;
-    }
-
-
-
-    private boolean handleBurnSelectionWidget(int bestLogId) {
-        if (!Rs2Widget.hasWidget("What would you like to burn?")) {
-
             return false;
         }
 
@@ -165,11 +115,6 @@ public class FiremakingScript {
                 || Rs2Player.isAnimating()
                 || Rs2Player.isInteracting(), 3_000);
         return true;
-    }
-
-    public boolean hasRequiredSuppliesInInventory() {
-        int bestLogId = resolveBestLogForCurrentLevel();
-        return hasRequiredSupplies(bestLogId);
     }
 
     private boolean hasRequiredSupplies(int bestLogId) {

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/woodcutting/script/WoodcuttingScript.java
@@ -243,7 +243,6 @@ public class WoodcuttingScript {
                 .closeAfterCompletion(false)
                 .build();
 
-
         if (!placeBuyOffer(request, axe)) {
             return false;
         }
@@ -257,28 +256,6 @@ public class WoodcuttingScript {
         if (Rs2Inventory.hasItem(axe.getItemId())) {
             return true;
         }
-
-
-
-        if (!placeBuyOffer(request, axe)) {
-            return false;
-        }
-
-            if (!placeBuyOffer(request, axe)) {
-                return false;
-            }
-
-
-        boolean boughtAxe = Global.sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || Rs2Inventory.hasItem(axe.getItemId()), BUY_WAIT_TIMEOUT_MS);
-        if (!boughtAxe) {
-            Rs2GrandExchange.abortAllOffers(true);
-        }
-
-        Rs2GrandExchange.collectAllToBank();
-        if (Rs2Inventory.hasItem(axe.getItemId())) {
-            return true;
-        }
-
 
         // Fallback verification: bank cache can be stale while GE is open, so check by opening bank.
         if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
@@ -298,25 +275,6 @@ public class WoodcuttingScript {
 
             log.debug("Failed to create buy offer for {} on attempt {}/{}", axe.getName(), attempt, BUY_OFFER_RETRY_COUNT);
             Global.sleep(600, 900);
-
-
-
-            boolean hasAxeInBank = Rs2Bank.hasItem(axe.getItemId());
-            Rs2Bank.closeBank();
-            return hasAxeInBank;
-        }
-    }
-
-    private boolean placeBuyOffer(GrandExchangeRequest request, Axe axe) {
-        for (int attempt = 1; attempt <= BUY_OFFER_RETRY_COUNT; attempt++) {
-            if (Rs2GrandExchange.processOffer(request)) {
-                return true;
-            }
-
-            log.debug("Failed to create buy offer for {} on attempt {}/{}", axe.getName(), attempt, BUY_OFFER_RETRY_COUNT);
-            Global.sleep(600, 900);
-
-
 
             if (!Rs2GrandExchange.isOpen()) {
                 if (!Rs2GrandExchange.openExchange()) {


### PR DESCRIPTION
### Motivation
- The KSP account builder scripts contained duplicated/garbled method blocks that broke control flow and prevented reliable compilation and execution.
- Restore coherent single implementations for core skill scripts (combat, woodcutting, firemaking) so the plugin behaves predictably.
- Increment the plugin version to reflect the functional fixes.

### Description
- Cleaned `CombatScript`, `WoodcuttingScript`, and `FiremakingScript` by removing duplicated/incorrect method blocks and restoring a single coherent implementation for methods such as `execute`, GE buy flow, and product/burn selection handling.
- Eliminated redundant/garbled variable declarations and duplicate logic that could lead to inconsistent behavior and compilation issues.
- Bumped `KSPAccountBuilderPlugin.VERSION` from `0.0.56` to `0.0.57` (update in `KSPAccountBuilderPlugin.java`).

### Testing
- Ran a regex-based duplicate-signature scan across the modified scripts to verify there are no repeated method signatures; the scan reported zero duplicate signatures after the cleanup.
- Attempted `gradle build -PpluginList=KSPAccountBuilderPlugin`, but the build could not complete in this environment due to inability to resolve the external Gradle plugin `io.freefair.lombok` (repository/network restrictions).
- No other automated tests were executed in this environment; the changes are limited to source cleanup and version bump.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06fb086d0833091fcbacd0bce7473)