### PR TITLE
fix: restore firemaking supply check method

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -27,7 +27,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.59";
+    public static final String VERSION = "0.0.60";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -41,6 +41,15 @@ public class FiremakingScript {
         return status;
     }
 
+    public boolean hasRequiredSuppliesInInventory() {
+        if (!Microbot.isLoggedIn()) {
+            return false;
+        }
+
+        int bestLogId = resolveBestLogForCurrentLevel();
+        return hasRequiredSupplies(bestLogId);
+    }
+
     public void execute() {
         if (!Microbot.isLoggedIn()) {
             status = "Waiting for login";


### PR DESCRIPTION
### Motivation
- Restore the missing firemaking inventory check so the account builder can verify firemaking readiness without compile errors.
- Bump the plugin version to follow repository versioning rules after the change.

### Description
- Add `hasRequiredSuppliesInInventory()` to `FiremakingScript` which returns `false` when logged out, resolves the best log for the current Firemaking level, and delegates to the existing `hasRequiredSupplies(int)` check.
- Update `KSPAccountBuilderPlugin.VERSION` from `0.0.59` to `0.0.60`.
- Modified files: `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java` and `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java`.

### Testing
- Attempted `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, but the Gradle wrapper download failed in this environment due to a proxy error (`HTTP/1.1 403 Forbidden`), so the build could not be executed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a073027d588330bbc581c146008c5d)