### PR TITLE
KSPAccountBuilder: bump version, add firemaking inventory check, and improve Grand Exchange axe buying

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -27,7 +27,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.59";
+    public static final String VERSION = "0.0.61";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/firemaking/script/FiremakingScript.java
@@ -41,6 +41,15 @@ public class FiremakingScript {
         return status;
     }
 
+    public boolean hasRequiredSuppliesInInventory() {
+        if (!Microbot.isLoggedIn()) {
+            return false;
+        }
+
+        int bestLogId = resolveBestLogForCurrentLevel();
+        return hasRequiredSupplies(bestLogId);
+    }
+
     public void execute() {
         if (!Microbot.isLoggedIn()) {
             status = "Waiting for login";


### PR DESCRIPTION
### Motivation
- Bump the plugin version to reflect recent changes and fixes. 
- Add a safe inventory check for the firemaking script to avoid operations while logged out. 
- Improve reliability of woodcutting tool acquisition by using the Grand Exchange with retries, slot management, and bank fallback.

### Description
- Updated plugin version constant from `0.0.59` to `0.0.61` in `KSPAccountBuilderPlugin`.
- Added `hasRequiredSuppliesInInventory()` to `FiremakingScript` which checks login state and resolves the best log before verifying supplies.
- Reworked axe purchase flow in `WoodcuttingScript` to use `Rs2GrandExchange`, `GrandExchangeRequest`, and `GrandExchangeAction` instead of the previous `Buy` flow, and added constants `BUY_WAIT_TIMEOUT_MS` and `BUY_OFFER_RETRY_COUNT` to control wait and retry behavior.
- Implemented `ensureExchangeSlotAvailable()` and `placeBuyOffer()` with retry logic and improved handling for collecting/aborting offers and verifying items in bank as a fallback.
- Adjusted imports and minor variable renames to align with the new GE-based flow.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a073027d588330bbc581c146008c5d)