### PR TITLE
Refactor looting and Grand Exchange collection; remove looting config and bump plugin version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
@@ -17,30 +17,23 @@ public interface KSPAccountBuilderConfig extends Config {
     String antibanSection = "antiban";
 
     @ConfigSection(
-            name = "Looting",
-            description = "Looting and burying behavior settings",
-            position = 1
-    )
-    String lootingSection = "looting";
-
-    @ConfigSection(
             name = "Task Rotation",
             description = "Task switching behavior",
-            position = 2
+            position = 1
     )
     String taskSection = "taskRotation";
 
     @ConfigSection(
             name = "Break Handler",
             description = "Custom run/break cycle behavior",
-            position = 3
+            position = 2
     )
     String breakSection = "breakHandler";
 
     @ConfigSection(
             name = "Debug Skills",
             description = "Enable or disable specific skills for debugging",
-            position = 4
+            position = 3
     )
     String debugSkillsSection = "debugSkills";
 
@@ -66,27 +59,7 @@ public interface KSPAccountBuilderConfig extends Config {
         return 0.2;
     }
 
-    @ConfigItem(
-            keyName = "enableBoneBury",
-            name = "Enable bone bury",
-            description = "Bury bones while running supported tasks",
-            position = 0,
-            section = lootingSection
-    )
-    default boolean enableBoneBury() {
-        return true;
-    }
 
-    @ConfigItem(
-            keyName = "enableCoinLooting",
-            name = "Enable coin looting",
-            description = "Loot ground coins while running supported tasks",
-            position = 1,
-            section = lootingSection
-    )
-    default boolean enableCoinLooting() {
-        return true;
-    }
 
     @ConfigItem(
             keyName = "taskSwitchMinutes",

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -27,7 +27,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.62";
+    public static final String VERSION = "0.0.65";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -159,7 +159,6 @@ public class KSPAccountBuilderScript extends Script {
         switch (activeTask) {
             case COMBAT:
                 currentTask = "Combat";
-                combatScript.configureLooting(config.enableBoneBury(), config.enableCoinLooting());
                 combatScript.execute();
                 status = combatScript.getStatus();
                 break;

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
@@ -1,10 +1,17 @@
 package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.loot;
 
 import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 
 public final class Loot {
     private Loot() {
         throw new UnsupportedOperationException("Utility class");
+    }
+
+
+    public static boolean lootCoins(int lootRadius) {
+        return Rs2GroundItem.lootCoins(new LootingParameters(lootRadius, 1, 1, 0, false, true, "coins"));
     }
 
     public static final int[] DEFAULT_LOOT = {

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
@@ -121,7 +121,7 @@ public final class Buy {
         }
 
         sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || !Rs2GrandExchange.isOpen(), BUY_WAIT_TIMEOUT_MS);
-        Rs2GrandExchange.collectAll(false);
+        collectOffersToInventory();
         Rs2GrandExchange.closeExchange();
         return true;
     }
@@ -241,6 +241,15 @@ public final class Buy {
         }
 
         Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
+    }
+
+    private static void collectOffersToInventory() {
+        if (!Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer()) {
+            return;
+        }
+
+        Rs2GrandExchange.collectAll(false);
         sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
     }
 


### PR DESCRIPTION
### Motivation
- Simplify and centralize looting behavior by removing per-plugin toggles and using shared ground-item utilities.
- Fix inconsistent Grand Exchange collection usage and ensure offers are collected explicitly to the intended container.
- Keep configuration sections ordered and remove unused settings to reduce UI clutter.

### Description
- Removed the separate "Looting" `ConfigSection` and the `enableBoneBury`/`enableCoinLooting` config items from `KSPAccountBuilderConfig`, and adjusted section positions.
- Bumped plugin `VERSION` from `0.0.62` to `0.0.65` in `KSPAccountBuilderPlugin`.
- Deleted the `configureLooting(...)` call in `KSPAccountBuilderScript` and removed dependence on the removed config flags.
- Added `Loot.lootCoins(int lootRadius)` and updated imports to use `LootingParameters` and `Rs2GroundItem` in `Loot` and `CombatScript`.
- Simplified combat looting logic in `CombatScript` by removing the kill-window tracking and per-instance flags, and by delegating coin looting to `Loot.lootCoins(...)`; kept bone burying and name-based looting behavior.
- Refactored Grand Exchange collection in `Buy` by introducing `collectOffersToInventory()` and replacing direct `Rs2GrandExchange.collectAll(false)` calls with the helper, while keeping `collectOffersToBank()` for bank collection.

### Testing
- Project compiled successfully after changes using the standard build (no compilation errors observed).
- No automated unit tests were run because there are no repository unit tests referencing these classes; no test failures reported during the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07619ca408330893521e2f84e0803)