### PR TITLE
Refactor looting and antiban behavior, add GE collection helpers, bump plugin version

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
@@ -17,30 +17,23 @@ public interface KSPAccountBuilderConfig extends Config {
     String antibanSection = "antiban";
 
     @ConfigSection(
-            name = "Looting",
-            description = "Looting and burying behavior settings",
-            position = 1
-    )
-    String lootingSection = "looting";
-
-    @ConfigSection(
             name = "Task Rotation",
             description = "Task switching behavior",
-            position = 2
+            position = 1
     )
     String taskSection = "taskRotation";
 
     @ConfigSection(
             name = "Break Handler",
             description = "Custom run/break cycle behavior",
-            position = 3
+            position = 2
     )
     String breakSection = "breakHandler";
 
     @ConfigSection(
             name = "Debug Skills",
             description = "Enable or disable specific skills for debugging",
-            position = 4
+            position = 3
     )
     String debugSkillsSection = "debugSkills";
 
@@ -66,27 +59,7 @@ public interface KSPAccountBuilderConfig extends Config {
         return 0.2;
     }
 
-    @ConfigItem(
-            keyName = "enableBoneBury",
-            name = "Enable bone bury",
-            description = "Bury bones while running supported tasks",
-            position = 0,
-            section = lootingSection
-    )
-    default boolean enableBoneBury() {
-        return true;
-    }
 
-    @ConfigItem(
-            keyName = "enableCoinLooting",
-            name = "Enable coin looting",
-            description = "Loot ground coins while running supported tasks",
-            position = 1,
-            section = lootingSection
-    )
-    default boolean enableCoinLooting() {
-        return true;
-    }
 
     @ConfigItem(
             keyName = "taskSwitchMinutes",

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -27,7 +27,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.62";
+    public static final String VERSION = "0.0.66";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
@@ -1,10 +1,17 @@
 package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.loot;
 
 import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 
 public final class Loot {
     private Loot() {
         throw new UnsupportedOperationException("Utility class");
+    }
+
+
+    public static boolean lootCoins(int lootRadius) {
+        return Rs2GroundItem.lootCoins(new LootingParameters(lootRadius, 1, 1, 0, false, true, "coins"));
     }
 
     public static final int[] DEFAULT_LOOT = {

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/ge/buy/Buy.java
@@ -121,7 +121,7 @@ public final class Buy {
         }
 
         sleepUntil(() -> Rs2GrandExchange.hasBoughtOffer() || !Rs2GrandExchange.isOpen(), BUY_WAIT_TIMEOUT_MS);
-        Rs2GrandExchange.collectAll(false);
+        collectOffersToInventory();
         Rs2GrandExchange.closeExchange();
         return true;
     }
@@ -241,6 +241,15 @@ public final class Buy {
         }
 
         Rs2GrandExchange.collectAllToBank();
+        sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
+    }
+
+    private static void collectOffersToInventory() {
+        if (!Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer()) {
+            return;
+        }
+
+        Rs2GrandExchange.collectAll(false);
         sleepUntil(() -> !Rs2GrandExchange.hasBoughtOffer() && !Rs2GrandExchange.hasSoldOffer(), 5000);
     }
 


### PR DESCRIPTION
### Motivation
- Simplify and centralize antiban behavior to avoid cooldown interruptions during non-woodcutting tasks.
- Remove per-task looting toggles and tighten combat looting logic to rely on shared utilities.
- Extract Grand Exchange collection logic into helper methods to avoid duplicated code and improve clarity.

### Description
- Updated plugin version from `0.0.62` to `0.0.66` in `KSPAccountBuilderPlugin`.
- Removed the `Looting` config section and its options (`enableBoneBury`, `enableCoinLooting`) from `KSPAccountBuilderConfig`, and adjusted section positions.
- Added `applyTaskSpecificAntibanPolicy(KSPAccountBuilderConfig)` in `KSPAccountBuilderScript` and call it from the main loop to set `Rs2AntibanSettings` per active task, and restricted `applyAntibanCycle()` to only run for `BuilderTask.WOODCUTTING`.
- Reworked combat looting in `CombatScript` by removing per-instance toggles and recent-kill tracking, simplifying `lootDropsInArea` to use shared `Loot.lootCoins` and unchanged bone/ item looting flows, and removed `configureLooting` and kill-window logic.
- Added `Loot.lootCoins` utility wrapper and imports in `Loot.java` to centralize coin-looting calls.
- Refactored Grand Exchange collection in `Buy` by extracting `collectOffersToInventory()` and `collectOffersToBank()` helpers and replacing inline calls with these helpers.

### Testing
- Built the project to verify compilation after refactors and the build completed successfully.
- Ran existing automated unit tests and integration checks in the repository and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07619ca408330893521e2f84e0803)