### PR TITLE
fix: reduce ksp combat looting and retarget delays

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -25,7 +25,7 @@ import java.awt.AWTException;
 public class KSPAccountBuilderPlugin extends Plugin {
 
 
-    public static final String VERSION = "0.0.72";
+    public static final String VERSION = "0.0.73";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -42,11 +42,11 @@ public class CombatScript {
     private static final int BUY_WAIT_TIMEOUT_MS = 20_000;
     private static final int LOOT_RADIUS = 8;
     private static final int GE_TROUT_RESTOCK_AMOUNT = 500;
-    private static final long REPOSITION_COOLDOWN_MS = 3_500L;
-    private static final int BURY_WAIT_TIMEOUT_MS = 1_200;
-    private static final int LOOT_ACTION_WAIT_TIMEOUT_MS = 1_800;
+    private static final long REPOSITION_COOLDOWN_MS = 1_500L;
+    private static final int BURY_WAIT_TIMEOUT_MS = 700;
+    private static final int LOOT_ACTION_WAIT_TIMEOUT_MS = 1_000;
 
-    private static final long LOOT_WAIT_AFTER_KILL_MS = 2_500L;
+    private static final long LOOT_WAIT_AFTER_KILL_MS = 1_200L;
 
     private String status = "Idle";
     private long lastRepositionAttemptAt = 0L;
@@ -54,7 +54,7 @@ public class CombatScript {
     private long waitForLootUntilMs = 0L;
 
 
-    private static final long LOOT_WAIT_AFTER_KILL_MS = 2_500L;
+    private static final long LOOT_WAIT_AFTER_KILL_MS = 1_200L;
 
     private String status = "Idle";
     private long lastRepositionAttemptAt = 0L;
@@ -324,7 +324,7 @@ public class CombatScript {
 
             sleepUntil(() -> Rs2Player.isMoving() || Rs2Player.isInteracting(), LOOT_ACTION_WAIT_TIMEOUT_MS);
 
-            sleepUntil(() -> Rs2Player.isMoving() || Rs2Player.isInteracting(), 2_500);
+            sleepUntil(() -> Rs2Player.isMoving() || Rs2Player.isInteracting(), 1_000);
 
 
 
@@ -414,7 +414,7 @@ public class CombatScript {
 
         cachedTargetNpcIndex = npc.getIndex();
         waitForLootUntilMs = 0L;
-        sleepUntil(() -> Rs2Player.isInteracting() || Rs2Player.isAnimating() || Rs2Player.isMoving(), 3_000);
+        sleepUntil(() -> Rs2Player.isInteracting() || Rs2Player.isAnimating() || Rs2Player.isMoving(), 1_500);
         return Rs2Player.isInteracting() || Rs2Player.isAnimating() || Rs2Player.isMoving();
     }
 


### PR DESCRIPTION
### Motivation
- Speed up KSP combat loop by reducing unnecessary waiting after kills and during looting/burying so the script retargets and continues faster.
- Reduce reposition cooldown so the bot attempts new targets/repositioning more frequently.
- Bump plugin version to reflect behavioural change per repository versioning rules.

### Description
- Lowered `REPOSITION_COOLDOWN_MS` from `3_500L` to `1_500L` to allow quicker repositioning and retarget attempts in `CombatScript` at `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java`.
- Reduced `BURY_WAIT_TIMEOUT_MS` from `1_200` to `700` to shorten bone-bury action wait.
- Reduced `LOOT_ACTION_WAIT_TIMEOUT_MS` from `1_800` to `1_000` to make looting follow-ups faster.
- Reduced `LOOT_WAIT_AFTER_KILL_MS` from `2_500L` to `1_200L` to shorten post-kill loot waiting.
- Shortened explicit `sleepUntil` waits used after looting from `2_500` to `1_000` and attack-engagement confirmation from `3_000` to `1_500` to speed transitions.
- Bumped `KSPAccountBuilderPlugin.VERSION` from `0.0.72` to `0.0.73` in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java`.

### Testing
- Attempted to build the plugin with `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, but the Gradle wrapper distribution download failed in this environment due to a proxy error (`HTTP/1.1 403 Forbidden`).
- Verified changes locally in the repository and committed the edits with message `fix: reduce ksp combat looting and retarget delays`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a089da169883308d32be32d0480946)