### PR TITLE
feat: add KSP account builder combat GE sell list

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/ge/sell/Sell.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/ge/sell/Sell.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.ge.sell;
+
+import net.runelite.api.ItemID;
+
+public final class Sell {
+    private Sell() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int[] DEFAULT_SELL = {
+            ItemID.COWHIDE,
+            ItemID.GOBLIN_MAIL,
+            ItemID.CHEFS_HAT,
+            ItemID.AIR_TALISMAN,
+            ItemID.EARTH_TALISMAN,
+            ItemID.STEEL_SCIMITAR,
+            ItemID.STEEL_LONGSWORD,
+            ItemID.IRON_ARROW,
+            ItemID.STEEL_ARROW,
+            ItemID.BRONZE_ARROW,
+            ItemID.MIND_RUNE,
+            ItemID.EARTH_RUNE,
+            ItemID.BODY_RUNE,
+            ItemID.CHAOS_RUNE,
+            ItemID.NATURE_RUNE,
+            ItemID.WATER_RUNE,
+            ItemID.LAW_RUNE,
+            ItemID.COSMIC_RUNE,
+            ItemID.DEATH_RUNE,
+            ItemID.LIMPWURT_ROOT,
+            ItemID.BODY_TALISMAN
+    };
+}


### PR DESCRIPTION
### Motivation
- Provide a centralized sell list for the KSP account builder combat flow so common combat drops can be listed for Grand Exchange selling.

### Description
- Add a new utility class `Sell` in `net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.ge.sell` that exposes `DEFAULT_SELL`, an `int[]` of ItemID constants for the requested items (cowhide, goblin mail, chef's hat, air/earth/body talismans, steel scimitar/longsword, iron/steel/bronze arrows, mind/earth/body/chaos/nature/water/law/cosmic/death runes, limpwurt root).

### Testing
- Attempted to run `./gradlew build -PpluginList=KSPAccountBuilderPlugin -x test`, but the Gradle wrapper download was blocked by a proxy resulting in `HTTP/1.1 403 Forbidden`, so an automated build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f2c131c0833085a7f52983b5d5db)