### PR TITLE
Refactor account builder to single Combat runner; add Combat GE sell/buy logic

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script.CombatScript;
-import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.firemaking.script.FiremakingScript;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
 import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
 import net.runelite.client.plugins.microbot.util.antiban.enums.PlayStyle;
@@ -16,8 +15,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public class KSPAccountBuilderScript extends Script {
@@ -29,14 +26,9 @@ public class KSPAccountBuilderScript extends Script {
     private static volatile String currentTask = "None";
     private static volatile Instant startedAt;
 
-    private final WoodcuttingScript woodcuttingScript = new WoodcuttingScript();
-    private final CombatScript combatScript = new CombatScript();
-    private final FiremakingScript firemakingScript = new FiremakingScript();
+    private final CombatScript combatRunner = new CombatScript();
 
     private volatile boolean startupBankingComplete;
-    private volatile BuilderTask activeTask = BuilderTask.WOODCUTTING;
-    private volatile Instant nextTaskSwitchAt;
-
     private volatile boolean breakActive;
     private volatile Instant nextBreakAt;
     private volatile Instant breakEndsAt;
@@ -51,15 +43,11 @@ public class KSPAccountBuilderScript extends Script {
     }
 
     public boolean run(KSPAccountBuilderConfig config) {
-        status = "Starting";
-        currentTask = "Initializing";
+        setStatusAndTask("Starting", "Combat");
         startedAt = Instant.now();
         startupBankingComplete = false;
-        activeTask = getRandomStartingTask(config);
-        nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
 
-        woodcuttingScript.initialize();
-        firemakingScript.initialize();
+        combatRunner.initialize();
         initializeBreakScheduling(config);
 
         Rs2Antiban.resetAntibanSettings();
@@ -79,14 +67,12 @@ public class KSPAccountBuilderScript extends Script {
                 updateClientTitle();
 
                 if (breakActive) {
-                    status = "On break";
-                    currentTask = "Break";
+                    setStatusAndTask("On break", "Break");
                     return;
                 }
 
                 if (!Microbot.isLoggedIn()) {
-                    status = "Waiting for login";
-                    currentTask = "Login";
+                    setStatusAndTask("Waiting for login", "Login");
                     return;
                 }
 
@@ -98,26 +84,16 @@ public class KSPAccountBuilderScript extends Script {
                     startupBankingComplete = true;
                 }
 
-                if (!isTaskEnabled(activeTask, config)) {
-                    activeTask = getRandomStartingTask(config);
-                }
+                currentTask = "Combat";
+                Rs2AntibanSettings.naturalMouse = true;
+                combatRunner.execute();
+                status = combatRunner.getStatus();
 
-                rotateTaskIfNeeded(config);
-
-                if (config.enableAntiban() && activeTask == BuilderTask.WOODCUTTING && Rs2AntibanSettings.actionCooldownActive) {
-                    status = "Antiban cooldown";
-                    return;
-                }
-
-                applyTaskSpecificAntibanPolicy(config);
-                executeActiveTask(config);
-
-                if (config.enableAntiban() && activeTask == BuilderTask.WOODCUTTING) {
+                if (config.enableAntiban()) {
                     applyAntibanCycle();
                 }
             } catch (Exception ex) {
-                status = "Error";
-                currentTask = "Error";
+                setStatusAndTask("Error", "Error");
                 log.error("KSPAccountBuilder encountered an error", ex);
             }
         }, LOOP_INITIAL_DELAY_MS, LOOP_DELAY_MS, TimeUnit.MILLISECONDS);
@@ -125,125 +101,20 @@ public class KSPAccountBuilderScript extends Script {
         return true;
     }
 
-
     private void applyAntibanCycle() {
         try {
-            // Defensive re-apply in case another script/util reset antiban runtime state.
             Rs2Antiban.setPlayStyle(PlayStyle.EXTREME_AGGRESSIVE);
             Rs2Antiban.actionCooldown();
             Rs2Antiban.takeMicroBreakByChance();
         } catch (NullPointerException ex) {
-            // Some antiban internals can transiently null out playStyle; recover without killing the main loop.
             log.warn("Antiban runtime state was null; resetting playstyle and continuing", ex);
             Rs2Antiban.setPlayStyle(PlayStyle.EXTREME_AGGRESSIVE);
             Rs2AntibanSettings.actionCooldownActive = false;
         }
     }
 
-    private BuilderTask getRandomStartingTask(KSPAccountBuilderConfig config) {
-        List<BuilderTask> enabledTasks = getEnabledTasks(config);
-        if (enabledTasks.isEmpty()) {
-            return BuilderTask.WOODCUTTING;
-        }
-
-        return enabledTasks.get(ThreadLocalRandom.current().nextInt(enabledTasks.size()));
-    }
-
-    private void applyTaskSpecificAntibanPolicy(KSPAccountBuilderConfig config) {
-        if (!config.enableAntiban()) {
-            return;
-        }
-
-        if (activeTask == BuilderTask.WOODCUTTING) {
-            Rs2AntibanSettings.actionCooldownChance = Math.max(0.0, Math.min(1.0, config.actionCooldownChance()));
-            return;
-        }
-
-        // Disable action cooldown entirely for non-woodcutting tasks (combat/firemaking)
-        // so antiban cooldown state does not interrupt combat loops.
-        Rs2AntibanSettings.actionCooldownActive = false;
-        Rs2AntibanSettings.actionCooldownChance = 0.0;
-    }
-
-    private void executeActiveTask(KSPAccountBuilderConfig config) {
-        updateNaturalMouseForActiveTask();
-
-        switch (activeTask) {
-            case COMBAT:
-                currentTask = "Combat";
-                combatScript.execute();
-                status = combatScript.getStatus();
-                break;
-            case FIREMAKING:
-                currentTask = "Firemaking";
-                firemakingScript.execute();
-                status = firemakingScript.getStatus();
-                break;
-            case WOODCUTTING:
-            default:
-                currentTask = "Woodcutting";
-                woodcuttingScript.execute();
-                status = woodcuttingScript.getStatus();
-                break;
-        }
-    }
-
-    private void updateNaturalMouseForActiveTask() {
-        Rs2AntibanSettings.naturalMouse = activeTask == BuilderTask.COMBAT || activeTask == BuilderTask.FIREMAKING;
-    }
-
-    private void rotateTaskIfNeeded(KSPAccountBuilderConfig config) {
-        if (nextTaskSwitchAt == null || Instant.now().isBefore(nextTaskSwitchAt)) {
-            return;
-        }
-
-        List<BuilderTask> enabledTasks = getEnabledTasks(config);
-        if (enabledTasks.isEmpty()) {
-            status = "No debug skills enabled";
-            currentTask = "Idle";
-            nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
-            return;
-        }
-
-        int currentIndex = enabledTasks.indexOf(activeTask);
-        if (currentIndex < 0) {
-            activeTask = enabledTasks.get(0);
-        } else {
-            activeTask = enabledTasks.get((currentIndex + 1) % enabledTasks.size());
-        }
-
-        nextTaskSwitchAt = Instant.now().plus(Duration.ofMinutes(Math.max(1, config.taskSwitchMinutes())));
-    }
-
-
-    private List<BuilderTask> getEnabledTasks(KSPAccountBuilderConfig config) {
-        List<BuilderTask> enabled = new ArrayList<>();
-        if (config.debugEnableWoodcutting()) {
-            enabled.add(BuilderTask.WOODCUTTING);
-        }
-        if (config.debugEnableCombat()) {
-            enabled.add(BuilderTask.COMBAT);
-        }
-        if (config.debugEnableFiremaking()) {
-            enabled.add(BuilderTask.FIREMAKING);
-        }
-        return enabled;
-    }
-
-    private boolean isTaskEnabled(BuilderTask task, KSPAccountBuilderConfig config) {
-        switch (task) {
-            case COMBAT:
-                return config.debugEnableCombat();
-            case FIREMAKING:
-                return config.debugEnableFiremaking();
-            case WOODCUTTING:
-            default:
-                return config.debugEnableWoodcutting();
-        }
-    }
-
     private boolean prepareForTaskStart() {
-        if (hasRequiredSuppliesForActiveTask()) {
+        if (combatRunner.hasCombatSetupReady()) {
             status = "Ready (inventory already prepared)";
             return true;
         }
@@ -261,25 +132,11 @@ public class KSPAccountBuilderScript extends Script {
         return true;
     }
 
-    private boolean hasRequiredSuppliesForActiveTask() {
-        switch (activeTask) {
-            case COMBAT:
-                return combatScript.hasCombatSetupReady();
-            case FIREMAKING:
-                return firemakingScript.hasRequiredSuppliesInInventory();
-            case WOODCUTTING:
-            default:
-                return woodcuttingScript.hasRequiredTools();
-        }
-    }
-
     private void initializeBreakScheduling(KSPAccountBuilderConfig config) {
-        breakActive = false;
-        breakEndsAt = null;
+        resetBreakState();
         originalTitle = safeGetTitle();
 
         if (!config.enableCustomBreakHandler()) {
-            nextBreakAt = null;
             return;
         }
 
@@ -288,16 +145,14 @@ public class KSPAccountBuilderScript extends Script {
 
     private void handleCustomBreaks(KSPAccountBuilderConfig config) {
         if (!config.enableCustomBreakHandler()) {
-            breakActive = false;
-            breakEndsAt = null;
+            resetBreakState();
             return;
         }
 
         Instant now = Instant.now();
         if (breakActive) {
             if (breakEndsAt != null && now.isAfter(breakEndsAt)) {
-                breakActive = false;
-                breakEndsAt = null;
+                clearActiveBreak();
                 nextBreakAt = now.plus(Duration.ofMinutes(randomBetween(config.minRunMinutes(), config.maxRunMinutes())));
                 restoreTitle();
                 return;
@@ -369,6 +224,22 @@ public class KSPAccountBuilderScript extends Script {
         }
     }
 
+
+    private void setStatusAndTask(String newStatus, String newTask) {
+        status = newStatus;
+        currentTask = newTask;
+    }
+
+    private void clearActiveBreak() {
+        breakActive = false;
+        breakEndsAt = null;
+    }
+
+    private void resetBreakState() {
+        breakActive = false;
+        breakEndsAt = null;
+        nextBreakAt = null;
+    }
     private int randomBetween(int min, int max) {
         int sanitizedMin = Math.max(1, Math.min(min, max));
         int sanitizedMax = Math.max(1, Math.max(min, max));
@@ -389,23 +260,13 @@ public class KSPAccountBuilderScript extends Script {
 
     @Override
     public void shutdown() {
-        status = "Stopped";
-        currentTask = "Stopped";
+        setStatusAndTask("Stopped", "Stopped");
         startupBankingComplete = false;
-        breakActive = false;
-        breakEndsAt = null;
-        nextBreakAt = null;
+        resetBreakState();
         restoreTitle();
-        woodcuttingScript.shutdown();
-        firemakingScript.shutdown();
+        combatRunner.shutdown();
         Rs2AntibanSettings.naturalMouse = false;
         Rs2Antiban.resetAntibanSettings();
         super.shutdown();
-    }
-
-    private enum BuilderTask {
-        WOODCUTTING,
-        COMBAT,
-        FIREMAKING
     }
 }

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/ge/sell/Sell.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/ge/sell/Sell.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.ge.sell;
+
+import net.runelite.api.ItemID;
+
+public final class Sell {
+    private Sell() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    public static final int[] DEFAULT_SELL = {
+            ItemID.COWHIDE,
+            ItemID.GOBLIN_MAIL,
+            ItemID.CHEFS_HAT,
+            ItemID.AIR_TALISMAN,
+            ItemID.EARTH_TALISMAN,
+            ItemID.STEEL_SCIMITAR,
+            ItemID.STEEL_LONGSWORD,
+            ItemID.IRON_ARROW,
+            ItemID.STEEL_ARROW,
+            ItemID.BRONZE_ARROW,
+            ItemID.MIND_RUNE,
+            ItemID.EARTH_RUNE,
+            ItemID.BODY_RUNE,
+            ItemID.CHAOS_RUNE,
+            ItemID.NATURE_RUNE,
+            ItemID.WATER_RUNE,
+            ItemID.LAW_RUNE,
+            ItemID.COSMIC_RUNE,
+            ItemID.DEATH_RUNE,
+            ItemID.LIMPWURT_ROOT,
+            ItemID.BODY_TALISMAN
+    };
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -1,0 +1,346 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.areas.MobArea;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.ge.sell.Sell;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.loot.Loot;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.needed.Gear;
+import net.runelite.client.plugins.microbot.util.Global;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+public final class CombatScript {
+    private static final WorldPoint GOBLIN_AREA_CENTER = new WorldPoint(3252, 3230, 0);
+    private static final int AREA_LOOT_RADIUS = 12;
+
+    private String status = "Idle";
+
+    public void initialize() {
+        status = "Initializing combat";
+    }
+
+    public void shutdown() {
+        status = "Combat stopped";
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public boolean hasCombatSetupReady() {
+        return hasFoodInInventory() && hasBestWeaponEquipped() && hasArmourPieceEquipped();
+    }
+
+    public void execute() {
+        if (!Microbot.isLoggedIn()) {
+            status = "Waiting for login";
+            return;
+        }
+
+        if (!ensureCombatSetup()) {
+            return;
+        }
+
+        if (!walkToGoblinArea()) {
+            return;
+        }
+
+        if (lootTrainingAreaDrops()) {
+            return;
+        }
+
+        attackGoblin();
+    }
+
+    private boolean ensureCombatSetup() {
+        if (hasCombatSetupReady() && hasFoodInInventory()) {
+            status = "Combat setup ready";
+            return true;
+        }
+
+        status = "Opening bank for combat setup";
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        withdrawFood();
+        withdrawBestAvailableGear();
+        equipInventoryGear();
+
+        if (!hasBestWeaponEquipped() || !hasArmourPieceEquipped()) {
+            status = "Missing upgrades - going to GE";
+            Rs2Bank.closeBank();
+            return sellLootAndBuyUpgrades();
+        }
+
+        Rs2Bank.closeBank();
+        return true;
+    }
+
+    private void withdrawFood() {
+        if (hasFoodInInventory()) {
+            return;
+        }
+
+        for (int foodId : Gear.FOOD_REQUIREMENTS) {
+            int needed = Math.max(0, Gear.MIN_TROUT_REQUIRED - Rs2Inventory.count(foodId));
+            if (needed > 0) {
+                Rs2Bank.withdrawX(foodId, needed);
+                Global.sleep(250);
+            }
+        }
+    }
+
+    private void withdrawBestAvailableGear() {
+        int bestWeapon = bestWeaponForAttackLevel();
+        if (!Rs2Equipment.isWearing(bestWeapon) && Rs2Bank.count(bestWeapon) > 0) {
+            Rs2Bank.withdrawX(bestWeapon, 1);
+            Global.sleep(200);
+        }
+
+        for (int armourId : bestArmourForDefenceLevel()) {
+            if (!Rs2Equipment.isWearing(armourId) && Rs2Bank.count(armourId) > 0) {
+                Rs2Bank.withdrawX(armourId, 1);
+                Global.sleep(150);
+            }
+        }
+
+        if (!Rs2Equipment.isWearing(Gear.AMULET_OF_POWER) && Rs2Bank.count(Gear.AMULET_OF_POWER) > 0) {
+            Rs2Bank.withdrawX(Gear.AMULET_OF_POWER, 1);
+            Global.sleep(150);
+        }
+    }
+
+    private void equipInventoryGear() {
+        Rs2Inventory.wield(bestWeaponForAttackLevel());
+        for (int armourId : bestArmourForDefenceLevel()) {
+            Rs2Inventory.wield(armourId);
+        }
+        Rs2Inventory.wield(Gear.AMULET_OF_POWER);
+    }
+
+    private boolean sellLootAndBuyUpgrades() {
+        if (!Rs2GrandExchange.walkToGrandExchange() || !Rs2GrandExchange.openExchange()) {
+            status = "Unable to access GE";
+            return false;
+        }
+
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            status = "Unable to open GE bank";
+            return false;
+        }
+
+        Rs2Bank.depositAll();
+        for (int sellId : Sell.DEFAULT_SELL) {
+            int bankCount = Rs2Bank.count(sellId);
+            if (bankCount > 1) {
+                Rs2Bank.withdrawX(sellId, bankCount - 1);
+                Global.sleep(120);
+            }
+        }
+        Rs2Bank.closeBank();
+
+        status = "Selling combat loot";
+        for (int sellId : Sell.DEFAULT_SELL) {
+            int invCount = Rs2Inventory.count(sellId);
+            if (invCount <= 0) {
+                continue;
+            }
+
+            String itemName = getItemName(sellId);
+            if (itemName == null || itemName.isBlank()) {
+                continue;
+            }
+
+            placeOffer(itemName, GrandExchangeAction.SELL, invCount);
+            Global.sleep(350);
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+
+        status = "Buying upgrades";
+        List<String> upgradesToBuy = getMissingUpgradeNames();
+        for (String itemName : upgradesToBuy) {
+            placeOffer(itemName, GrandExchangeAction.BUY, 1);
+            Global.sleep(350);
+        }
+
+        Rs2GrandExchange.collectAllToBank();
+        Rs2GrandExchange.closeExchange();
+        return true;
+    }
+
+    private void placeOffer(String itemName, GrandExchangeAction action, int quantity) {
+        GrandExchangeRequest request = GrandExchangeRequest.builder()
+                .action(action)
+                .itemName(itemName)
+                .quantity(Math.max(1, quantity))
+                .percent(8)
+                .closeAfterCompletion(false)
+                .build();
+        Rs2GrandExchange.processOffer(request);
+    }
+
+    private List<String> getMissingUpgradeNames() {
+        List<String> names = new ArrayList<>();
+
+        int bestWeapon = bestWeaponForAttackLevel();
+        if (!Rs2Equipment.isWearing(bestWeapon) && Rs2Bank.count(bestWeapon) <= 0) {
+            String weaponName = getItemName(bestWeapon);
+            if (weaponName != null) {
+                names.add(weaponName);
+            }
+        }
+
+        for (int armourId : bestArmourForDefenceLevel()) {
+            if (!Rs2Equipment.isWearing(armourId) && Rs2Bank.count(armourId) <= 0) {
+                String armourName = getItemName(armourId);
+                if (armourName != null) {
+                    names.add(armourName);
+                }
+            }
+        }
+
+        if (!Rs2Equipment.isWearing(Gear.AMULET_OF_POWER) && Rs2Bank.count(Gear.AMULET_OF_POWER) <= 0) {
+            String amuletName = getItemName(Gear.AMULET_OF_POWER);
+            if (amuletName != null) {
+                names.add(amuletName);
+            }
+        }
+
+        return names;
+    }
+
+    private String getItemName(int itemId) {
+        ItemComposition item = Microbot.getClientThread()
+                .runOnClientThreadOptional(() -> Microbot.getItemManager().getItemComposition(itemId))
+                .orElse(null);
+        return item == null ? null : item.getName();
+    }
+
+    private boolean walkToGoblinArea() {
+        if (MobArea.GOBLINS.contains(Rs2Player.getWorldLocation())) {
+            return true;
+        }
+
+        status = "Walking to goblin area";
+        return Rs2Walker.walkTo(GOBLIN_AREA_CENTER);
+    }
+
+    private boolean lootTrainingAreaDrops() {
+        if (Loot.lootCoins(AREA_LOOT_RADIUS)) {
+            status = "Looting coins";
+            return true;
+        }
+
+        for (int lootId : Loot.DEFAULT_LOOT) {
+            if (Rs2GroundItem.loot(lootId, AREA_LOOT_RADIUS)) {
+                status = "Looting drops";
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void attackGoblin() {
+        if (Rs2Player.isInCombat() || Rs2Player.isInteracting() || Rs2Player.isAnimating()) {
+            status = "Fighting";
+            return;
+        }
+
+        status = "Attacking goblin";
+        Rs2Npc.attack("Goblin");
+    }
+
+    private boolean hasFoodInInventory() {
+        for (int foodId : Gear.FOOD_REQUIREMENTS) {
+            if (Rs2Inventory.count(foodId) >= Gear.MIN_TROUT_REQUIRED) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasBestWeaponEquipped() {
+        return Rs2Equipment.isWearing(bestWeaponForAttackLevel());
+    }
+
+    private boolean hasArmourPieceEquipped() {
+        for (int armourId : bestArmourForDefenceLevel()) {
+            if (Rs2Equipment.isWearing(armourId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int bestWeaponForAttackLevel() {
+        int attack = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
+        if (attack >= 40) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[0];
+        if (attack >= 30) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[1];
+        if (attack >= 20) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[2];
+        if (attack >= 10) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[3];
+        if (attack >= 5) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[4];
+        if (attack >= 1) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[5];
+        return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[6];
+    }
+
+    private int[] bestArmourForDefenceLevel() {
+        int defence = Microbot.getClient().getRealSkillLevel(Skill.DEFENCE);
+
+        if (defence >= 40) return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[0],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[1],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[2],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[3]
+        };
+        if (defence >= 30) return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[4],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[5],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[6],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[7]
+        };
+        if (defence >= 20) return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[8],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[9],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[10],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[11]
+        };
+        if (defence >= 10) return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[12],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[13],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[14],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[15]
+        };
+        if (defence >= 1) return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[16],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[17],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[18],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[19]
+        };
+
+        return new int[]{
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[20],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[21],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[22],
+                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[23]
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Simplify the KSP account builder by focusing operation on a dedicated combat runner and remove the old multi-skill rotation machinery to reduce complexity and edge cases.
- Add automated combat looting and Grand Exchange sell/buy logic to let the combat flow equip best gear and purchase upgrades when needed.

### Description
- Introduced `CombatScript` implementing combat flow including bank interactions, withdrawing/equipping gear, walking to goblin training area, looting, attacking, and GE sell/buy via `Rs2GrandExchange` and `GrandExchangeRequest`.
- Added `Sell.DEFAULT_SELL` utility list for common combat loot item IDs to be sold on the GE.
- Replaced the previous multi-task orchestration in `KSPAccountBuilderScript` with a single `combatRunner` instance, removed woodcutting/firemaking scripts and task rotation, and simplified antiban handling to always apply the aggressive playstyle in combat mode.
- Refactored status and break handling helpers in `KSPAccountBuilderScript` by adding `setStatusAndTask`, `resetBreakState`, and `clearActiveBreak`, and updated `prepareForTaskStart` to use the combat runner readiness check.

### Testing
- Performed a full project build using `mvn -DskipTests=false package`, which completed successfully.
- Executed the repository's automated tests using `mvn test`, and the existing tests ran and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f2c131c0833085a7f52983b5d5db)