### PR TITLE
fix: resolve duplicate declarations in CombatScript and KSPAccountBuilderScript

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -26,7 +26,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.76";
+    public static final String VERSION = "0.0.77";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java
@@ -31,15 +31,6 @@ public class KSPAccountBuilderScript extends Script {
     private final CombatScript combatRunner = new CombatScript();
 
 
-
-
-    private final net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script.CombatScript combatScript =
-            new net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.script.CombatScript();
-
-    private final CombatScript combatScript = new CombatScript();
-
-
-
     private volatile boolean startupBankingComplete;
     private volatile boolean breakActive;
     private volatile Instant nextBreakAt;
@@ -59,26 +50,7 @@ public class KSPAccountBuilderScript extends Script {
         setStatusAndTask("Starting", "Combat");
         startedAt = Instant.now();
         startupBankingComplete = false;
-
         combatRunner.initialize();
-
-
-        setStatusAndTask("Starting", "Combat");
-        startedAt = Instant.now();
-        startupBankingComplete = false;
-
-        combatRunner.initialize();
-
-        status = "Starting";
-        currentTask = "Combat";
-        startedAt = Instant.now();
-        startupBankingComplete = false;
-
-
-        combatRunner.initialize();
-
-        combatScript.initialize();
-
 
         initializeBreakScheduling(config);
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -25,10 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
-
-public final class CombatScript {
-
-
 public class CombatScript {
 
 


### PR DESCRIPTION
### Motivation

- Remove syntactic/compile errors caused by duplicate class and field declarations in the KSP account builder combat code so the plugin can compile and run normally.

### Description

- Removed an accidental duplicate class declaration in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java` so the file contains a single valid `CombatScript` class definition.
- Removed duplicate `CombatScript` field declarations and eliminated repeated startup/initialization blocks in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderScript.java`, leaving a single `combatRunner` and a single initialization flow in `run(...)`.
- Bumped the plugin version constant in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java` from `0.0.76` to `0.0.77` to reflect the change.

### Testing

- Attempted to run `./gradlew build -PpluginList=KSPAccountBuilderPlugin` to validate compilation, but the Gradle wrapper download failed in this environment due to a network/proxy error (`HTTP/1.1 403 Forbidden`), so the build could not complete.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a207cef4d48330b7c10d86411f5ccd)