### PR TITLE
Enhance combat script: team cape handling, inventory/banking, bone burying, gear selection, and version bump

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -26,7 +26,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.77";
+    public static final String VERSION = "0.0.85";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/loot/Loot.java
@@ -11,10 +11,12 @@ public final class Loot {
 
 
     public static boolean lootCoins(int lootRadius) {
-        return Rs2GroundItem.lootCoins(new LootingParameters(lootRadius, 1, 1, 0, false, true, "coins"));
+        return Rs2GroundItem.lootCoins(new LootingParameters(lootRadius, 1, 1, 0, true, true, "coins"));
     }
 
     public static final int[] DEFAULT_LOOT = {
+            ItemID.BONES,
+            ItemID.BIG_BONES,
             ItemID.COWHIDE,
             ItemID.GOBLIN_MAIL,
             ItemID.CHEFS_HAT,

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/needed/Gear.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/needed/Gear.java
@@ -25,6 +25,8 @@ public final class Gear {
             "Team cape"
     };
 
+    public static final String DEFAULT_TEAM_CAPE_NAME = "Team-1 cape";
+
     public static final int[] BEST_MELEE_WEAPONS_BY_LEVEL = {
             Swords.RUNE_SCIMITAR,
             Swords.ADAMANT_SCIMITAR,

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -2,23 +2,33 @@ package net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.scr
 
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
 import net.runelite.api.Skill;
+import net.runelite.api.VarPlayer;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.plugins.microbot.inventory.Rs2ItemModel;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.areas.MobArea;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.gear.armour.Armour;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.gear.swords.Swords;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.ge.sell.Sell;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.loot.Loot;
+import net.runelite.client.plugins.microbot.globval.enums.InterfaceTab;
 import net.runelite.client.plugins.microbot.kspaccountbuilder.skills.combat.needed.Gear;
 import net.runelite.client.plugins.microbot.util.Global;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.combat.Rs2Combat;
 import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
 import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
 import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.grounditem.LootingParameters;
 import net.runelite.client.plugins.microbot.util.grounditem.Rs2GroundItem;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.npc.Rs2Npc;
 import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.tabs.Rs2Tab;
 import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
 
 import java.util.ArrayList;
@@ -46,7 +56,7 @@ public class CombatScript {
     }
 
     public boolean hasCombatSetupReady() {
-        return hasFoodInInventory() && hasBestWeaponEquipped() && hasArmourPieceEquipped();
+        return hasFoodInInventory() && hasBestWeaponEquipped() && hasBestArmourEquipped() && isWearingTeamCape();
     }
 
     public void execute() {
@@ -55,7 +65,24 @@ public class CombatScript {
             return;
         }
 
+        if (isPlayerBusy()) {
+            status = "Waiting for current action";
+            return;
+        }
+
         if (!ensureCombatSetup()) {
+            return;
+        }
+
+        if (buryBonesInInventory()) {
+            return;
+        }
+
+        if (bankWhenInventoryFull()) {
+            return;
+        }
+
+        if (!ensureBalancedMeleeStatsTraining()) {
             return;
         }
 
@@ -85,7 +112,7 @@ public class CombatScript {
         withdrawBestAvailableGear();
         equipInventoryGear();
 
-        if (!hasBestWeaponEquipped() || !hasArmourPieceEquipped()) {
+        if (!hasBestWeaponEquipped() || !hasBestArmourEquipped() || !isWearingTeamCape()) {
             status = "Missing upgrades - going to GE";
             Rs2Bank.closeBank();
             return sellLootAndBuyUpgrades();
@@ -127,6 +154,11 @@ public class CombatScript {
             Rs2Bank.withdrawX(Gear.AMULET_OF_POWER, 1);
             Global.sleep(150);
         }
+
+        if (!isWearingTeamCape() && hasTeamCapeInBank()) {
+            Rs2Bank.withdrawX(this::isTeamCapeItem, 1);
+            Global.sleep(150);
+        }
     }
 
     private void equipInventoryGear() {
@@ -135,6 +167,9 @@ public class CombatScript {
             Rs2Inventory.wield(armourId);
         }
         Rs2Inventory.wield(Gear.AMULET_OF_POWER);
+        if (!isWearingTeamCape()) {
+            Rs2Inventory.interact(this::isTeamCapeItem, "Wear");
+        }
     }
 
     private boolean sellLootAndBuyUpgrades() {
@@ -226,6 +261,10 @@ public class CombatScript {
             }
         }
 
+        if (!isWearingTeamCape() && !hasTeamCapeInBank()) {
+            names.add(Gear.DEFAULT_TEAM_CAPE_NAME);
+        }
+
         return names;
     }
 
@@ -236,9 +275,158 @@ public class CombatScript {
         return item == null ? null : item.getName();
     }
 
+    private boolean isWearingTeamCape() {
+        return Rs2Equipment.isWearing(this::isTeamCapeItem)
+                || Rs2Equipment.isWearing(Gear.DEFAULT_TEAM_CAPE_NAME);
+    }
+
+    private boolean hasTeamCapeInBank() {
+        return Rs2Bank.hasItem(this::isTeamCapeItem)
+                || Rs2Bank.hasItem(Gear.DEFAULT_TEAM_CAPE_NAME);
+    }
+
+    private boolean isTeamCapeItem(Rs2ItemModel item) {
+        if (item == null || item.getName() == null) {
+            return false;
+        }
+
+        String lowerName = item.getName().toLowerCase();
+        if (lowerName.contains(Gear.DEFAULT_TEAM_CAPE_NAME.toLowerCase())) {
+            return true;
+        }
+
+        for (String teamCapeNameMatcher : Gear.TEAM_CAPE_NAME_MATCHERS) {
+            if (lowerName.contains(teamCapeNameMatcher.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean buryBonesInInventory() {
+        List<Rs2ItemModel> bones = Rs2Inventory.getBones();
+        if (bones != null && !bones.isEmpty() && Rs2Inventory.interact(bones.get(0), "Bury")) {
+            status = "Burying bones";
+            Global.sleep(350);
+            return true;
+        }
+
+        if (Rs2Inventory.interact(ItemID.BIG_BONES, "Bury")) {
+            status = "Burying big bones";
+            Global.sleep(350);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean bankWhenInventoryFull() {
+        if (!Rs2Inventory.isFull()) {
+            return false;
+        }
+
+        status = "Inventory full - banking";
+        if (!Rs2Bank.walkToBankAndUseBank() || !Rs2Bank.isOpen()) {
+            return false;
+        }
+
+        Rs2Bank.depositAll(item -> item != null && shouldBankInventoryItem(item));
+        Global.sleep(250);
+
+        withdrawFood();
+        withdrawBestAvailableGear();
+        equipInventoryGear();
+
+        Rs2Bank.closeBank();
+        return true;
+    }
+
+    private boolean shouldBankInventoryItem(Rs2ItemModel item) {
+        if (item.getName() != null && isTeamCapeItem(item)) {
+            return false;
+        }
+
+        return !isGearItemId(item.getId());
+    }
+
+    private boolean isGearItemId(int itemId) {
+        if (itemId == Gear.AMULET_OF_POWER) {
+            return true;
+        }
+
+        for (int foodId : Gear.FOOD_REQUIREMENTS) {
+            if (foodId == itemId) {
+                return true;
+            }
+        }
+
+        for (int weaponId : Gear.BEST_MELEE_WEAPONS_BY_LEVEL) {
+            if (weaponId == itemId) {
+                return true;
+            }
+        }
+
+        for (int armourId : Gear.BEST_MELEE_ARMOUR_BY_LEVEL) {
+            if (armourId == itemId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean ensureBalancedMeleeStatsTraining() {
+        if (Rs2Player.isInCombat() || Rs2Player.isInteracting()) {
+            return true;
+        }
+
+        int attackLevel = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
+        int strengthLevel = Microbot.getClient().getRealSkillLevel(Skill.STRENGTH);
+        int defenceLevel = Microbot.getClient().getRealSkillLevel(Skill.DEFENCE);
+
+        int targetStyle = 1;
+        if (attackLevel <= strengthLevel && attackLevel <= defenceLevel) {
+            targetStyle = 0;
+        } else if (defenceLevel <= attackLevel && defenceLevel <= strengthLevel) {
+            targetStyle = 3;
+        }
+
+        int currentStyle = Microbot.getVarbitPlayerValue(VarPlayer.ATTACK_STYLE);
+        if (currentStyle == targetStyle) {
+            return true;
+        }
+
+        if (Rs2Tab.getCurrentTab() != InterfaceTab.COMBAT) {
+            Rs2Tab.switchToCombatOptionsTab();
+            Global.sleep(250);
+        }
+
+        status = "Balancing melee stats";
+        Rs2Combat.setAttackStyle(mapStyleWidget(targetStyle));
+        Global.sleep(250);
+        return true;
+    }
+
+    private WidgetInfo mapStyleWidget(int styleIndex) {
+        if (styleIndex == 0) {
+            return WidgetInfo.COMBAT_STYLE_ONE;
+        }
+        if (styleIndex == 1) {
+            return WidgetInfo.COMBAT_STYLE_TWO;
+        }
+        if (styleIndex == 2) {
+            return WidgetInfo.COMBAT_STYLE_THREE;
+        }
+        return WidgetInfo.COMBAT_STYLE_FOUR;
+    }
+
     private boolean walkToGoblinArea() {
         if (MobArea.GOBLINS.contains(Rs2Player.getWorldLocation())) {
             return true;
+        }
+
+        if (isPlayerBusy()) {
+            return false;
         }
 
         status = "Walking to goblin area";
@@ -246,13 +434,30 @@ public class CombatScript {
     }
 
     private boolean lootTrainingAreaDrops() {
+        if (isPlayerBusy()) {
+            return false;
+        }
+
         if (Loot.lootCoins(AREA_LOOT_RADIUS)) {
             status = "Looting coins";
             return true;
         }
 
         for (int lootId : Loot.DEFAULT_LOOT) {
-            if (Rs2GroundItem.loot(lootId, AREA_LOOT_RADIUS)) {
+            String lootName = getItemName(lootId);
+            if (lootName == null || lootName.isBlank()) {
+                continue;
+            }
+
+            if (Rs2GroundItem.lootItemsBasedOnNames(new LootingParameters(
+                    AREA_LOOT_RADIUS,
+                    1,
+                    1,
+                    0,
+                    true,
+                    true,
+                    lootName
+            ))) {
                 status = "Looting drops";
                 return true;
             }
@@ -262,13 +467,21 @@ public class CombatScript {
     }
 
     private void attackGoblin() {
-        if (Rs2Player.isInCombat() || Rs2Player.isInteracting() || Rs2Player.isAnimating()) {
+        if (Rs2Player.isInCombat()) {
             status = "Fighting";
+            return;
+        }
+
+        if (isPlayerBusy()) {
             return;
         }
 
         status = "Attacking goblin";
         Rs2Npc.attack("Goblin");
+    }
+
+    private boolean isPlayerBusy() {
+        return Rs2Player.isMoving() || Rs2Player.isInteracting() || Rs2Player.isAnimating();
     }
 
     private boolean hasFoodInInventory() {
@@ -284,65 +497,65 @@ public class CombatScript {
         return Rs2Equipment.isWearing(bestWeaponForAttackLevel());
     }
 
-    private boolean hasArmourPieceEquipped() {
+    private boolean hasBestArmourEquipped() {
         for (int armourId : bestArmourForDefenceLevel()) {
-            if (Rs2Equipment.isWearing(armourId)) {
-                return true;
+            if (!Rs2Equipment.isWearing(armourId)) {
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     private int bestWeaponForAttackLevel() {
         int attack = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
-        if (attack >= 40) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[0];
-        if (attack >= 30) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[1];
-        if (attack >= 20) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[2];
-        if (attack >= 10) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[3];
-        if (attack >= 5) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[4];
-        if (attack >= 1) return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[5];
-        return Gear.BEST_MELEE_WEAPONS_BY_LEVEL[6];
+        if (attack >= Swords.RUNE_SCIMITAR_ATTACK_LEVEL) return Swords.RUNE_SCIMITAR;
+        if (attack >= Swords.ADAMANT_SCIMITAR_ATTACK_LEVEL) return Swords.ADAMANT_SCIMITAR;
+        if (attack >= Swords.MITHRIL_SCIMITAR_ATTACK_LEVEL) return Swords.MITHRIL_SCIMITAR;
+        if (attack >= Swords.BLACK_SCIMITAR_ATTACK_LEVEL) return Swords.BLACK_SCIMITAR;
+        if (attack >= Swords.STEEL_SCIMITAR_ATTACK_LEVEL) return Swords.STEEL_SCIMITAR;
+        if (attack >= Swords.IRON_SCIMITAR_ATTACK_LEVEL) return Swords.IRON_SCIMITAR;
+        return Swords.BRONZE_SCIMITAR;
     }
 
     private int[] bestArmourForDefenceLevel() {
         int defence = Microbot.getClient().getRealSkillLevel(Skill.DEFENCE);
 
-        if (defence >= 40) return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[0],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[1],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[2],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[3]
+        if (defence >= Armour.RUNE_ARMOUR_EQUIP_LEVEL) return new int[]{
+                Armour.RUNE_FULL_HELM,
+                Armour.RUNE_PLATEBODY,
+                Armour.RUNE_PLATELEGS,
+                Armour.RUNE_KITESHIELD
         };
-        if (defence >= 30) return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[4],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[5],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[6],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[7]
+        if (defence >= Armour.ADAMANT_ARMOUR_EQUIP_LEVEL) return new int[]{
+                Armour.ADAMANT_FULL_HELM,
+                Armour.ADAMANT_PLATEBODY,
+                Armour.ADAMANT_PLATELEGS,
+                Armour.ADAMANT_KITESHIELD
         };
-        if (defence >= 20) return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[8],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[9],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[10],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[11]
+        if (defence >= Armour.MITHRIL_ARMOUR_EQUIP_LEVEL) return new int[]{
+                Armour.MITHRIL_FULL_HELM,
+                Armour.MITHRIL_PLATEBODY,
+                Armour.MITHRIL_PLATELEGS,
+                Armour.MITHRIL_KITESHIELD
         };
-        if (defence >= 10) return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[12],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[13],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[14],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[15]
+        if (defence >= Armour.BLACK_ARMOUR_EQUIP_LEVEL) return new int[]{
+                Armour.BLACK_FULL_HELM,
+                Armour.BLACK_PLATEBODY,
+                Armour.BLACK_PLATELEGS,
+                Armour.BLACK_KITESHIELD
         };
-        if (defence >= 1) return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[16],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[17],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[18],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[19]
+        if (defence >= Armour.IRON_ARMOUR_EQUIP_LEVEL) return new int[]{
+                Armour.IRON_FULL_HELM,
+                Armour.IRON_PLATEBODY,
+                Armour.IRON_PLATELEGS,
+                Armour.IRON_KITESHIELD
         };
 
         return new int[]{
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[20],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[21],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[22],
-                Gear.BEST_MELEE_ARMOUR_BY_LEVEL[23]
+                Armour.BRONZE_FULL_HELM,
+                Armour.BRONZE_PLATEBODY,
+                Armour.BRONZE_PLATELEGS,
+                Armour.BRONZE_KITESHIELD
         };
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure combat runs more reliably by preventing actions while the player is busy and by preserving/auto-equipping a team cape for progression. 
- Improve inventory management by auto-burying bones and banking non-gear items when inventory is full to avoid stalls. 
- Make equipment and loot handling more robust by replacing index-based arrays with typed `Swords`/`Armour` constants and switching to name-based ground item looting.

### Description
- Bumped plugin `VERSION` from `0.0.77` to `0.0.85` in `KSPAccountBuilderPlugin`.
- Adjusted coin looting parameters and added `ItemID.BONES` and `ItemID.BIG_BONES` to `Loot.DEFAULT_LOOT` in `Loot.java`.
- Added `Gear.DEFAULT_TEAM_CAPE_NAME` and introduced team-cape awareness across the combat flow, including `isTeamCapeItem`, `isWearingTeamCape`, and `hasTeamCapeInBank` checks used when withdrawing, equipping, and deciding GE purchases.
- Implemented inventory management helpers in `CombatScript`: `isPlayerBusy`, `buryBonesInInventory`, `bankWhenInventoryFull`, `shouldBankInventoryItem`, and `isGearItemId` to keep important gear and team capes and to deposit unwanted items when full.
- Reworked gear selection and checks to use explicit `Swords` and `Armour` constants and equip-level thresholds, replaced `hasArmourPieceEquipped` with `hasBestArmourEquipped` that requires the full set, and updated `bestWeaponForAttackLevel`/`bestArmourForDefenceLevel` to return concrete IDs.
- Improved looting to resolve item names before attempting pickup and switched to `Rs2GroundItem.lootItemsBasedOnNames` with `LootingParameters` for safer name-based looting.
- Added melee training balancing via `ensureBalancedMeleeStatsTraining` which inspects real skill levels, maps desired attack style, switches to the combat tab, and sets the attack style through `Rs2Combat` using mapped `WidgetInfo` entries.
- Updated control flow to short-circuit actions when the player is busy and to perform burying/banking/GE flows as needed during `execute` and `ensureCombatSetup`.

### Testing
- Ran a full project build and test run with `mvn -DskipTests=false test`, which completed successfully and existing automated tests passed.
- No new automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a209ef61dc8330a8c66a6b194c0691)