### PR TITLE
fix: reduce combat idle delay between targets and looting

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -26,7 +26,7 @@ public class KSPAccountBuilderPlugin extends Plugin {
 
 
 
-    public static final String VERSION = "0.0.77";
+    public static final String VERSION = "0.0.78";
 
 
 

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -635,7 +635,15 @@ public class CombatScript {
     }
 
     private boolean isPlayerBusy() {
-        return Rs2Player.isMoving() || Rs2Player.isInteracting() || Rs2Player.isAnimating();
+        if (Rs2Player.isMoving()) {
+            return true;
+        }
+
+        if (Rs2Player.isInCombat()) {
+            return Rs2Player.isInteracting() || Rs2Player.isAnimating();
+        }
+
+        return false;
     }
 
     private boolean hasFoodInInventory() {


### PR DESCRIPTION
### Motivation
- Reduce unnecessary idle time between kills and looting by ensuring the script does not treat out-of-combat animation/interacting states as busy so it can retarget goblins or pick up drops faster.

### Description
- Update `isPlayerBusy()` in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java` to treat movement as a hard busy state and only consider `isInteracting()`/`isAnimating()` while `isInCombat()`; and bump `KSPAccountBuilderPlugin.VERSION` to `0.0.78` in `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java`.

### Testing
- Attempted automated build with `./gradlew build -PpluginList=KSPAccountBuilderPlugin`, but the Gradle wrapper download was blocked by a proxy (`HTTP/1.1 403 Forbidden`) in this environment so no build/tests completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2444115948330b2db9ea7b5e83fd7)