### PR TITLE
fix: keep combat training at cows until melee stats reach 20

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -235,25 +235,6 @@ public class CombatScript {
     private boolean walkToTrainingArea() {
         if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
             return false;
-
-    private boolean isPlayerBusy() {
-        if (Rs2Player.isMoving()) {
-            return true;
-        }
-
-        if (Rs2Player.isInCombat()) {
-            return Rs2Player.isInteracting() || Rs2Player.isAnimating();
-        }
-
-        return false;
-    }
-
-    private boolean hasFoodInInventory() {
-        for (int foodId : Gear.FOOD_REQUIREMENTS) {
-            if (Rs2Inventory.count(foodId) >= Gear.MIN_TROUT_REQUIRED) {
-                return true;
-            }
-
         }
 
         if (shouldTrainAtCows()) {
@@ -266,7 +247,14 @@ public class CombatScript {
     }
 
     private boolean shouldTrainAtCows() {
-        return getMeleeLevel(Skill.ATTACK) >= 5 && getMeleeLevel(Skill.STRENGTH) >= 5 && getMeleeLevel(Skill.DEFENCE) >= 5;
+        int attack = getMeleeLevel(Skill.ATTACK);
+        int strength = getMeleeLevel(Skill.STRENGTH);
+        int defence = getMeleeLevel(Skill.DEFENCE);
+
+        boolean allAtLeastFive = attack >= 5 && strength >= 5 && defence >= 5;
+        boolean anyBelowTwenty = attack < 20 || strength < 20 || defence < 20;
+
+        return allAtLeastFive && anyBelowTwenty;
     }
 
     private boolean isInTrainingArea() {


### PR DESCRIPTION
### Motivation
- Combat routing was sending accounts to goblins once melee stats exceeded 5 even when Attack/Strength/Defence still needed to reach level 20, causing incorrect training progression.
- The `walkToTrainingArea()` method contained malformed control flow which could interfere with area selection and walking logic.

### Description
- Restored correct control flow in `walkToTrainingArea()` so the method returns early when the player is busy and otherwise routes to the correct area based on `shouldTrainAtCows()`.
- Replaced the broken/misaligned block and removed unreachable stray logic that was embedded inside `walkToTrainingArea()`.
- Updated `shouldTrainAtCows()` to return `true` only when all melee stats (Attack/Strength/Defence) are at least `5` and at least one of them is still below `20`, so cows are used for progression up to level `20`.

### Testing
- Attempted to run a compile check with the Gradle wrapper using `bash ./gradlew compileJava -q`, but the wrapper download failed due to an external proxy returning `HTTP/1.1 403 Forbidden` so compilation could not be validated here.
- Attempted `./gradlew compileJava -q` directly but the wrapper was not executable in this environment (`Permission denied`), so no automated build or tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f9a513548330acdece80a25f8ff1)