### PR TITLE
Refine cow training selection and remove unused player checks in CombatScript

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/skills/combat/script/CombatScript.java
@@ -235,25 +235,6 @@ public class CombatScript {
     private boolean walkToTrainingArea() {
         if (Rs2Player.isMoving() || Rs2Player.isAnimating() || Rs2Player.isInteracting()) {
             return false;
-
-    private boolean isPlayerBusy() {
-        if (Rs2Player.isMoving()) {
-            return true;
-        }
-
-        if (Rs2Player.isInCombat()) {
-            return Rs2Player.isInteracting() || Rs2Player.isAnimating();
-        }
-
-        return false;
-    }
-
-    private boolean hasFoodInInventory() {
-        for (int foodId : Gear.FOOD_REQUIREMENTS) {
-            if (Rs2Inventory.count(foodId) >= Gear.MIN_TROUT_REQUIRED) {
-                return true;
-            }
-
         }
 
         if (shouldTrainAtCows()) {
@@ -266,7 +247,14 @@ public class CombatScript {
     }
 
     private boolean shouldTrainAtCows() {
-        return getMeleeLevel(Skill.ATTACK) >= 5 && getMeleeLevel(Skill.STRENGTH) >= 5 && getMeleeLevel(Skill.DEFENCE) >= 5;
+        int attack = getMeleeLevel(Skill.ATTACK);
+        int strength = getMeleeLevel(Skill.STRENGTH);
+        int defence = getMeleeLevel(Skill.DEFENCE);
+
+        boolean hasPassedGoblinStarterLevels = attack >= 5 || strength >= 5 || defence >= 5;
+        boolean stillNeedsMeleeLevels = attack < 20 || strength < 20 || defence < 20;
+
+        return hasPassedGoblinStarterLevels && stillNeedsMeleeLevels;
     }
 
     private boolean isInTrainingArea() {


### PR DESCRIPTION
### Motivation

- Make the decision to train at cows more nuanced so the script transitions after initial goblin progress but continues until melee levels reach a reasonable threshold. 
- Remove unused/duplicated player state checks to simplify the combat flow. 
- Clean up walking logic to the training areas for clarity.

### Description

- Replace the previous `shouldTrainAtCows` check (requiring all melee stats >= 5) with a new implementation that returns true when any melee stat is >= 5 and any melee stat is still < 20. 
- Introduce local variables `attack`, `strength`, and `defence` in `shouldTrainAtCows` and compute `hasPassedGoblinStarterLevels` and `stillNeedsMeleeLevels` to make the condition explicit. 
- Remove the unused methods `isPlayerBusy` and `hasFoodInInventory` from `CombatScript`. 
- Tidy `walkToTrainingArea` control flow and status messages for walking to cow or goblin areas.

### Testing

- Built the project with `./gradlew build` to verify compilation, which completed successfully. 
- Ran the test suite with `./gradlew test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f9a513548330acdece80a25f8ff1)