### PR TITLE
Add KSP Account Builder plugin with mining script, overlay, and config

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderConfig.java
@@ -1,0 +1,30 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigInformation;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("KSPAccountBuilder")
+@ConfigInformation("Start near a bank with pickaxes available. The script will mine based on level and bank when inventory is full.")
+public interface KSPAccountBuilderConfig extends Config {
+    @ConfigItem(
+            keyName = "guide",
+            name = "How to use",
+            description = "Quick setup steps for KSP Account Builder.",
+            position = 0
+    )
+    default String guide() {
+        return "1) Start near a bank. 2) Ensure pickaxes are in bank. 3) Enable plugin and let it handle mining + banking.";
+    }
+
+    @ConfigItem(
+            keyName = "antiban",
+            name = "Enable Antiban",
+            description = "Toggle antiban behavior during mining.",
+            position = 1
+    )
+    default boolean antiban() {
+        return true;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderOverlay.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderOverlay.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class KSPAccountBuilderOverlay extends OverlayPanel {
+
+    @Inject
+    KSPAccountBuilderOverlay() {
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("KSP Account Builder v" + KSPAccountBuilderPlugin.version)
+                .color(Color.CYAN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status")
+                .right("Running")
+                .build());
+
+        return super.render(graphics);
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KSPAccountBuilderPlugin.java
@@ -1,0 +1,55 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.mining.script.MScript;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+        name = PluginConstants.KSP + "Account Builder",
+        description = "Automates early account-building mining tasks.",
+        tags = {"ksp", "account", "builder", "mining"},
+        version = KSPAccountBuilderPlugin.version,
+        minClientVersion = "1.9.6",
+        enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+        isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KSPAccountBuilderPlugin extends Plugin {
+    public static final String version = "1.0.0";
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private KSPAccountBuilderOverlay overlay;
+
+    @Inject
+    private MScript miningScript;
+
+    @Inject
+    private KSPAccountBuilderConfig config;
+
+    @Provides
+    KSPAccountBuilderConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(KSPAccountBuilderConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        overlayManager.add(overlay);
+        miningScript.run();
+    }
+
+    @Override
+    protected void shutDown() {
+        overlayManager.remove(overlay);
+        miningScript.shutdown();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/Areas.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/Areas.java
@@ -1,0 +1,43 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.mining;
+
+public final class Areas {
+    public static final Area COPPER_TIN_AREA = new Area(3280, 3371, 3291, 3360);
+    public static final Area IRON_AREA = new Area(3284, 3370, 3289, 3366);
+    public static final Area CLAY_AREA = new Area(3184, 3363, 3171, 3379);
+    public static final Area SILVER_ORE_AREA = new Area(3170, 3370, 3178, 3364);
+    public static final Area COAL_AREA = new Area(3077, 3422, 3084, 3417);
+    public static final Area GOLD_ORE_AREA = new Area(3292, 3289, 3295, 3285);
+
+    private Areas() {
+    }
+
+    public static final class Area {
+        private final int x1;
+        private final int y1;
+        private final int x2;
+        private final int y2;
+
+        public Area(int x1, int y1, int x2, int y2) {
+            this.x1 = x1;
+            this.y1 = y1;
+            this.x2 = x2;
+            this.y2 = y2;
+        }
+
+        public int getX1() {
+            return x1;
+        }
+
+        public int getY1() {
+            return y1;
+        }
+
+        public int getX2() {
+            return x2;
+        }
+
+        public int getY2() {
+            return y2;
+        }
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/pickelevel/PickaxeELevel.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/pickelevel/PickaxeELevel.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.mining.pickelevel;
+
+public enum PickaxeELevel {
+    BRONZE(1),
+    IRON(1),
+    STEEL(5),
+    BLACK(10),
+    MITRHIL(20),
+    ADAMANT(30),
+    RUNE(40);
+
+    private final int level;
+
+    PickaxeELevel(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/pickulevel/PickaxeMLevel.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/pickulevel/PickaxeMLevel.java
@@ -1,0 +1,21 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.mining.pickulevel;
+
+public enum PickaxeMLevel {
+    BRONZE(1),
+    IRON(1),
+    STEEL(6),
+    BLACK(11),
+    MITHRIL(21),
+    ADAMANT(31),
+    RUNE(41);
+
+    private final int level;
+
+    PickaxeMLevel(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/rocklevel/RockLevels.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/rocklevel/RockLevels.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.mining.rocklevel;
+
+public enum RockLevels {
+    COPPER(1),
+    TIN(1),
+    CLAY(1),
+    RUNE_ESSENCE(1),
+    IRON_ORE(15),
+    SILVER(20),
+    COAL(30),
+    GOLD(40);
+
+    private final int level;
+
+    RockLevels(int level) {
+        this.level = level;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/script/MScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/mining/script/MScript.java
@@ -1,0 +1,231 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder.mining.script;
+
+import net.runelite.api.Skill;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.mining.Areas;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.mining.pickelevel.PickaxeELevel;
+import net.runelite.client.plugins.microbot.kspaccountbuilder.mining.pickulevel.PickaxeMLevel;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.bank.enums.BankLocation;
+import net.runelite.client.plugins.microbot.util.equipment.Rs2Equipment;
+import net.runelite.client.plugins.microbot.util.gameobject.Rs2GameObject;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.walker.Rs2Walker;
+
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+
+public class MScript extends Script {
+    private static final String COPPER_ORE = "Copper ore";
+    private static final String TIN_ORE = "Tin ore";
+
+    public boolean run() {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(this::execute, 0, 800, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void execute() {
+        if (!Microbot.isLoggedIn() || !super.run()) return;
+        if (Microbot.getClient().getRealSkillLevel(Skill.MINING) < 1) return;
+        if (Rs2Player.isAnimating() || Rs2Player.isMoving()) return;
+
+        if (Rs2Inventory.isFull()) {
+            bankAndDepositEverythingExceptPickaxe();
+            return;
+        }
+
+        equipBestAvailablePickaxeForCurrentAttackLevel();
+
+        MiningTarget target = getMiningTargetForCurrentLevel();
+
+        if (!isInsideArea(target.area)) {
+            walkToAreaCenter(target.area);
+            return;
+        }
+
+        mineTarget(target);
+    }
+
+    private MiningTarget getMiningTargetForCurrentLevel() {
+        int miningLevel = Microbot.getClient().getRealSkillLevel(Skill.MINING);
+
+        if (miningLevel >= 30) {
+            return new MiningTarget(Areas.COAL_AREA, "Coal", false);
+        }
+        if (miningLevel >= 20) {
+            return new MiningTarget(Areas.SILVER_ORE_AREA, "Silver", false);
+        }
+        if (miningLevel >= 15) {
+            return new MiningTarget(Areas.IRON_AREA, "Iron", false);
+        }
+
+        return new MiningTarget(Areas.COPPER_TIN_AREA, "", true);
+    }
+
+    private void mineTarget(MiningTarget target) {
+        if (target.balancedCopperTin) {
+            mineEqualCopperAndTin();
+            return;
+        }
+
+        if (!Rs2GameObject.interact(target.rockName, "Mine")) {
+            Rs2GameObject.interact("Rocks", "Mine");
+        }
+
+        sleepUntil(Rs2Player::isAnimating, 5000);
+    }
+
+    private void bankAndDepositEverythingExceptPickaxe() {
+        BankLocation nearestBank = Rs2Bank.getNearestBank();
+        if (nearestBank == null) return;
+
+        if (!Rs2Bank.isOpen()) {
+            Rs2Bank.walkToBankAndUseBank(nearestBank);
+            return;
+        }
+
+        handlePickaxeUpgradeAtBank();
+
+        String bestPickaxe = getBestMiningPickaxeName();
+        if (bestPickaxe != null) {
+            Rs2Bank.depositAllExcept(bestPickaxe);
+        } else {
+            Rs2Bank.depositAll();
+        }
+
+        depositOutdatedPickaxes(bestPickaxe);
+        if (hasOutdatedPickaxeInInventory(bestPickaxe)) {
+            return;
+        }
+
+        sleepUntil(() -> !Rs2Inventory.isFull(), 5000);
+        Rs2Bank.closeBank();
+    }
+
+    private void handlePickaxeUpgradeAtBank() {
+        equipBestAvailablePickaxeForCurrentAttackLevel();
+
+        String bestPickaxe = getBestMiningPickaxeName();
+        if (bestPickaxe == null) return;
+
+        if (!Rs2Equipment.isWearing(bestPickaxe)) {
+            if (Rs2Inventory.hasItem(bestPickaxe)) {
+                Rs2Inventory.interact(bestPickaxe, "Wield");
+            } else if (Rs2Bank.hasItem(bestPickaxe)) {
+                Rs2Bank.withdrawAndEquip(bestPickaxe);
+            }
+        }
+
+        depositOutdatedPickaxes(bestPickaxe);
+    }
+
+    private String getBestMiningPickaxeName() {
+        int miningLevel = Microbot.getClient().getRealSkillLevel(Skill.MINING);
+
+        PickaxeMLevel bestPickaxe = java.util.Arrays.stream(PickaxeMLevel.values())
+                .filter(p -> p.getLevel() <= miningLevel)
+                .max(Comparator.comparingInt(PickaxeMLevel::getLevel))
+                .orElse(null);
+
+        if (bestPickaxe == null) return null;
+        return formatPickaxeName(bestPickaxe.name());
+    }
+
+    private void depositOutdatedPickaxes(String bestPickaxe) {
+        for (PickaxeMLevel pickaxe : PickaxeMLevel.values()) {
+            String pickaxeName = formatPickaxeName(pickaxe.name());
+            if (pickaxeName.equalsIgnoreCase(bestPickaxe)) continue;
+            if (Rs2Inventory.hasItem(pickaxeName)) {
+                Rs2Bank.depositAll(pickaxeName);
+            }
+        }
+    }
+
+    private boolean hasOutdatedPickaxeInInventory(String bestPickaxe) {
+        for (PickaxeMLevel pickaxe : PickaxeMLevel.values()) {
+            String pickaxeName = formatPickaxeName(pickaxe.name());
+            if (!pickaxeName.equalsIgnoreCase(bestPickaxe) && Rs2Inventory.hasItem(pickaxeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void equipBestAvailablePickaxeForCurrentAttackLevel() {
+        int attackLevel = Microbot.getClient().getRealSkillLevel(Skill.ATTACK);
+
+        PickaxeELevel bestPickaxe = java.util.Arrays.stream(PickaxeELevel.values())
+                .filter(p -> p.getLevel() <= attackLevel)
+                .max(Comparator.comparingInt(PickaxeELevel::getLevel))
+                .orElse(null);
+
+        if (bestPickaxe == null) return;
+
+        String pickaxeName = formatPickaxeName(bestPickaxe.name());
+        if (Rs2Equipment.isWearing(pickaxeName)) return;
+
+        if (!Rs2Bank.isOpen() && !Rs2Inventory.hasItem(pickaxeName)) {
+            BankLocation nearestBank = Rs2Bank.getNearestBank();
+            if (nearestBank == null) return;
+            Rs2Bank.walkToBankAndUseBank(nearestBank);
+            return;
+        }
+
+        if (Rs2Bank.isOpen() && !Rs2Inventory.hasItem(pickaxeName)) {
+            Rs2Bank.withdrawAndEquip(pickaxeName);
+            return;
+        }
+
+        if (Rs2Inventory.hasItem(pickaxeName)) {
+            Rs2Inventory.interact(pickaxeName, "Wield");
+        }
+    }
+
+    private void mineEqualCopperAndTin() {
+        int copperCount = Rs2Inventory.count(COPPER_ORE);
+        int tinCount = Rs2Inventory.count(TIN_ORE);
+        String targetRock = copperCount <= tinCount ? "Copper" : "Tin";
+
+        if (!Rs2GameObject.interact(targetRock, "Mine")) {
+            Rs2GameObject.interact("Rocks", "Mine");
+        }
+
+        sleepUntil(() -> Rs2Player.isAnimating() || Rs2Inventory.count(COPPER_ORE) + Rs2Inventory.count(TIN_ORE) > copperCount + tinCount, 5000);
+    }
+
+    private boolean isInsideArea(Areas.Area area) {
+        WorldPoint point = Rs2Player.getWorldLocation();
+        int minX = Math.min(area.getX1(), area.getX2());
+        int maxX = Math.max(area.getX1(), area.getX2());
+        int minY = Math.min(area.getY1(), area.getY2());
+        int maxY = Math.max(area.getY1(), area.getY2());
+
+        return point.getX() >= minX && point.getX() <= maxX && point.getY() >= minY && point.getY() <= maxY;
+    }
+
+    private void walkToAreaCenter(Areas.Area area) {
+        int x = (area.getX1() + area.getX2()) / 2;
+        int y = (area.getY1() + area.getY2()) / 2;
+        Rs2Walker.walkTo(new WorldPoint(x, y, 0));
+    }
+
+    private String formatPickaxeName(String enumName) {
+        String normalized = enumName.equals("MITRHIL") ? "MITHRIL" : enumName;
+        return normalized.substring(0, 1) + normalized.substring(1).toLowerCase() + " pickaxe";
+    }
+
+    private static final class MiningTarget {
+        private final Areas.Area area;
+        private final String rockName;
+        private final boolean balancedCopperTin;
+
+        private MiningTarget(Areas.Area area, String rockName, boolean balancedCopperTin) {
+            this.area = area;
+            this.rockName = rockName;
+            this.balancedCopperTin = balancedCopperTin;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an automated plugin to accelerate early account-building mining tasks by selecting appropriate ore targets and managing pickaxes and banking. 
- Handle pickaxe selection and upgrades based on player `ATTACK`/`MINING` levels and ensure balanced Copper/Tin collection for early levels. 
- Expose a small config and an on-screen overlay to show plugin status and usage guidance.

### Description
- Added a new plugin `KSPAccountBuilderPlugin` with startup/shutdown lifecycle that registers the overlay and runs `MScript` which schedules mining logic. 
- Implemented `MScript` to pick mining targets by level, walk to area centers, mine, handle inventory-full behavior, bank interactions, deposit logic, and pickaxe equip/upgrade flows. 
- Introduced domain objects and enums for world areas and level thresholds via `Areas`, `RockLevels`, `PickaxeELevel`, and `PickaxeMLevel`, plus a helper to format pickaxe names. 
- Added `KSPAccountBuilderConfig` for a quick usage guide and an `antiban` toggle, and `KSPAccountBuilderOverlay` to render plugin version and status in the UI.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b004f1988330b1b1bafe5e2c6a0d)