### PR TITLE
feat: add KSP account builder plugin skeleton

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderConfig.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderConfig.java
@@ -1,0 +1,22 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup(KspAccountBuilderConfig.CONFIG_GROUP)
+public interface KspAccountBuilderConfig extends Config
+{
+    String CONFIG_GROUP = "kspaccountbuilder";
+
+    @ConfigItem(
+        keyName = "enabled",
+        name = "Enable script",
+        description = "Enable the account builder automation skeleton",
+        position = 0
+    )
+    default boolean enabled()
+    {
+        return false;
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderPlugin.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderPlugin.java
@@ -1,0 +1,52 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.microbot.PluginConstants;
+
+import javax.inject.Inject;
+
+@PluginDescriptor(
+    name = PluginConstants.KSP + "Account Builder",
+    description = "Skeleton plugin for KSP account builder automation",
+    tags = {"microbot", "ksp", "account", "builder"},
+    authors = {"KSP"},
+    version = KspAccountBuilderPlugin.VERSION,
+    minClientVersion = "2.0.13",
+    enabledByDefault = PluginConstants.DEFAULT_ENABLED,
+    isExternal = PluginConstants.IS_EXTERNAL
+)
+@Slf4j
+public class KspAccountBuilderPlugin extends Plugin
+{
+    public static final String VERSION = "0.0.1";
+
+    @Inject
+    private KspAccountBuilderScript script;
+
+    @Inject
+    private KspAccountBuilderConfig config;
+
+    @Provides
+    KspAccountBuilderConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(KspAccountBuilderConfig.class);
+    }
+
+    @Override
+    protected void startUp()
+    {
+        log.info("Starting KSP Account Builder plugin");
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown()
+    {
+        log.info("Stopping KSP Account Builder plugin");
+        script.shutdown();
+    }
+}

--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/KspAccountBuilderScript.java
@@ -1,0 +1,32 @@
+package net.runelite.client.plugins.microbot.kspaccountbuilder;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+
+import javax.inject.Singleton;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class KspAccountBuilderScript extends Script
+{
+    public boolean run(KspAccountBuilderConfig config)
+    {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() ->
+        {
+            if (!super.run() || !Microbot.isLoggedIn() || !config.enabled())
+            {
+                return;
+            }
+
+            // TODO: Implement account-building steps.
+        }, 0, 600, TimeUnit.MILLISECONDS);
+
+        return true;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        super.shutdown();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, consistent plugin scaffold for a KSP account builder under the existing Microbot plugin architecture so future automation can be implemented iteratively.

### Description
- Add package `net.runelite.client.plugins.microbot.kspaccountbuilder` with a plugin descriptor class `KspAccountBuilderPlugin` that wires startup/shutdown and provides the config.
- Add `KspAccountBuilderConfig` with a `ConfigGroup` of `kspaccountbuilder` and an `enabled` toggle to control the script.
- Add `KspAccountBuilderScript` extending `Script` with a scheduled loop skeleton and a `// TODO` placeholder for account-building logic.
- Files added: `KspAccountBuilderPlugin.java`, `KspAccountBuilderConfig.java`, and `KspAccountBuilderScript.java` under `src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/`.

### Testing
- No automated unit tests were added for this scaffold.
- Attempted to run `./gradlew build -PpluginList=KspAccountBuilderPlugin`, which failed in this environment due to external dependency resolution returning HTTP 403 (network/proxy issue), so build validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ce4aa66c8330a018cbe06c098d1f)