### PR TITLE
fix: follow Flipping Copilot highlights for SellScript

### DIFF
--- a/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/tasks/skilling/selling/sellscript/SellScript.java
+++ b/src/main/java/net/runelite/client/plugins/microbot/kspaccountbuilder/tasks/skilling/selling/sellscript/SellScript.java
@@ -122,8 +122,10 @@ public class SellScript extends Script
                 return;
             }
 
-            if (handleCopilotSellFlow())
+            if (isCopilotAvailable())
             {
+                Microbot.status = "Following Flipping Copilot";
+                handleCopilotSellFlow();
                 return;
             }
 
@@ -141,18 +143,6 @@ public class SellScript extends Script
             if (nextItem == null)
             {
                 Microbot.status = "Waiting at GE";
-                return;
-            }
-
-            if (isCopilotAvailable())
-            {
-                Microbot.status = "Selling " + nextItem.getName();
-                if (Rs2Inventory.interact(nextItem.getName(), "Offer"))
-                {
-                    lastActionAtMs = System.currentTimeMillis();
-                    sleepUntil(() -> Rs2GrandExchange.isOfferScreenOpen()
-                            || isCopilotPromptVisible(), 3_000);
-                }
                 return;
             }
 
@@ -591,10 +581,19 @@ public class SellScript extends Script
             return false;
         }
 
-        Widget highlightedWidget = getWidgetFromOverlay(getSuggestionType(getSuggestion()));
+        String suggestionType = getSuggestionType(getSuggestion());
+        Widget highlightedWidget = getWidgetFromOverlay(suggestionType);
         if (highlightedWidget == null || !Rs2Widget.isWidgetVisible(highlightedWidget.getId()))
         {
             return false;
+        }
+
+        if (shouldCollectToBank(suggestionType, highlightedWidget))
+        {
+            Rs2GrandExchange.collectAllToBank();
+            sleepUntil(() -> !Rs2GrandExchange.hasSoldOffer(), 5_000);
+            lastActionAtMs = System.currentTimeMillis();
+            return true;
         }
 
         Rs2Widget.clickWidget(highlightedWidget);
@@ -615,6 +614,36 @@ public class SellScript extends Script
             }
         }
         return true;
+    }
+
+    private boolean shouldCollectToBank(String suggestionType, Widget highlightedWidget)
+    {
+        if (Objects.equals(suggestionType, "collect"))
+        {
+            return true;
+        }
+
+        if (highlightedWidget.getText() != null
+                && highlightedWidget.getText().toLowerCase(Locale.ENGLISH).contains("collect"))
+        {
+            return true;
+        }
+
+        String[] actions = highlightedWidget.getActions();
+        if (actions == null)
+        {
+            return false;
+        }
+
+        for (String action : actions)
+        {
+            if (action != null && action.toLowerCase(Locale.ENGLISH).contains("collect"))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private Widget getWidgetFromOverlay(String suggestionType)


### PR DESCRIPTION
### Motivation

- Ensure `SellScript` follows Flipping Copilot's highlighted actions instead of blindly initiating offers from arbitrary inventory items.  
- When Copilot suggests collecting sold items (or highlights a collect widget), collect to the bank rather than clicking into inventory.  
- Reduce mismatches between Copilot guidance and the script's fallback behavior to improve reliability at the Grand Exchange.

### Description

- Updated the main sell loop in `SellScript` to prefer Copilot-driven flow by checking `isCopilotAvailable()` and calling `handleCopilotSellFlow()` when available, and added a status message `"Following Flipping Copilot"`.  
- Removed the previous branch that started offers directly from inventory when Copilot was available so Copilot-guided highlights drive the flow.  
- Refactored `checkAndClickHighlightedWidgets()` to read the Copilot `suggestionType` first and to call a new helper `shouldCollectToBank(...)` before clicking a highlighted widget.  
- Added `shouldCollectToBank(String suggestionType, Widget highlightedWidget)` which returns true if the suggestion type, widget text, or widget actions indicate a collect operation, and when detected the script calls `Rs2GrandExchange.collectAllToBank()` and waits for sold offers to clear.

### Testing

- Attempted to compile with `./gradlew -q compileJava`, but the build could not complete in this environment because dependency resolution for `com.microbot:microbot:2.0.61` failed with HTTP 403 from upstream sources.  
- No further automated tests were executed due to the environment dependency failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc480ad1a8833088b5c9562c396b23)